### PR TITLE
Added an option labelEscape (default to true) to be able to render raw labels

### DIFF
--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -136,11 +136,12 @@ class ListRenderer extends Renderer implements RendererInterface
     public function renderLink(ItemInterface $item, array $options = array())
     {
         $options = array_merge($this->getDefaultOptions(), $options);
+        $label = ($options['labelEscape']) ? $this->escape($item->getLabel()) : $item->getLabel();
 
         if ($item->getUri() && (!$item->isCurrent() || $options['currentAsLink'])) {
-            $text = sprintf('<a href="%s"%s>%s</a>', $this->escape($item->getUri()), $this->renderHtmlAttributes($item->getLinkAttributes()), $this->escape($item->getLabel()));
+            $text = sprintf('<a href="%s"%s>%s</a>', $this->escape($item->getUri()), $this->renderHtmlAttributes($item->getLinkAttributes()), $label);
         } else {
-            $text = sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $this->escape($item->getLabel()));
+            $text = sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $label);
         }
 
         return $this->format($text, 'link', $item->getLevel());
@@ -185,6 +186,7 @@ class ListRenderer extends Renderer implements RendererInterface
             'ancestorClass' => 'current_ancestor',
             'firstClass' => 'first',
             'lastClass' => 'last',
+            'labelEscape' => true,
         );
     }
 }

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -103,6 +103,7 @@ class TwigRenderer extends \Twig_Extension implements RendererInterface
             'lastClass' => 'last',
             'template' => $this->defaultTemplate,
             'compressed' => $this->renderCompressed,
+            'labelEscape' => true,
         );
     }
 }

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -70,4 +70,4 @@
 {% endif %}
 {% endblock %}
 
-{% block label %}{{ item.label }}{% endblock %}
+{% block label %}{{ options.labelEscape ? item.label|e : item.label|raw }}{% endblock %}


### PR DESCRIPTION
This is useful when you want complex label content.

i.e :

```
<a href="#">
    Contact
    <span class="subtitle">Contact us or send us a message</span>
</a>
```
