### PR TITLE
[Helper] Adding some error checking for bad provider return

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -40,7 +40,13 @@ class Helper
             if (null === $this->menuProvider) {
                 throw new \BadMethodCallException('A menu provider must be set to retrieve a menu');
             }
-            $menu = $this->menuProvider->get($menu);
+
+            $menuName = $menu;
+            $menu = $this->menuProvider->get($menuName);
+
+            if (!$menu instanceof ItemInterface) {
+                throw new \LogicException(sprintf('The menu "%s" exists, but is not a valid menu item object. Check where you created the menu to be sure it returns an ItemInterface object.', $menuName));
+            }
         }
 
         foreach ($path as $child) {


### PR DESCRIPTION
Hey guys!

I'm open to other approaches, but I wanted to add some error checking in case the MenuProvider doesn't actually return a menu. The user case - in Symfony - is a menu service that's not actual a menu instance (e.g. you forget your return statement in your factory method, as I did).

Thanks!
