### PR TITLE
Add support for attributes on the children collection.

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -129,6 +129,35 @@ interface ItemInterface extends  \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @return array
      */
+    function getChildrenAttributes();
+
+    /**
+     * Provides a fluent interface
+     *
+     * @param  array $childrenAttributes
+     * @return \Knp\Menu\ItemInterface
+     */
+    function setChildrenAttributes(array $childrenAttributes);
+
+    /**
+     * @param  string $name     The name of the attribute to return
+     * @param  mixed  $default  The value to return if the attribute doesn't exist
+     * @return mixed
+     */
+    function getChildrenAttribute($name, $default = null);
+
+    /**
+     * Provides a fluent interface
+     *
+     * @param string $name
+     * @param string $value
+     * @return \Knp\Menu\ItemInterface
+     */
+    function setChildrenAttribute($name, $value);
+
+    /**
+     * @return array
+     */
     function getLabelAttributes();
 
     /**

--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -17,6 +17,7 @@ class MenuFactory implements FactoryInterface
                 'label' => null,
                 'attributes' => array(),
                 'linkAttributes' => array(),
+                'childrenAttributes' => array(),
                 'labelAttributes' => array(),
                 'display' => true,
                 'displayChildren' => true,
@@ -29,6 +30,7 @@ class MenuFactory implements FactoryInterface
             ->setLabel($options['label'])
             ->setAttributes($options['attributes'])
             ->setLinkAttributes($options['linkAttributes'])
+            ->setChildrenAttributes($options['childrenAttributes'])
             ->setLabelAttributes($options['labelAttributes'])
             ->setDisplay($options['display'])
             ->setDisplayChildren($options['displayChildren'])

--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -16,6 +16,7 @@ class MenuItem implements ItemInterface
     protected $name = null; // the name of this menu item (used for id by parent menu)
     protected $label = null; // the label to output, name is used by default
     protected $linkAttributes = array(); // an array of attributes for the item link
+    protected $childrenAttributes = array(); // an array of attributes for the children list
     protected $labelAttributes = array(); // an array of attributes for the item text
     protected $uri = null; // the uri to use in the anchor tag
     protected $attributes = array(); // an array of attributes for the li
@@ -232,6 +233,53 @@ class MenuItem implements ItemInterface
     public function setLinkAttribute($name, $value)
     {
         $this->linkAttributes[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getChildrenAttributes()
+    {
+        return $this->childrenAttributes;
+    }
+
+    /**
+     * @param  array $childrenAttributes
+     * @return \Knp\Menu\ItemInterface
+     */
+    public function setChildrenAttributes(array $childrenAttributes)
+    {
+        $this->childrenAttributes = $childrenAttributes;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $name     The name of the attribute to return
+     * @param  mixed  $default  The value to return if the attribute doesn't exist
+     *
+     * @return mixed
+     */
+    public function getChildrenAttribute($name, $default = null)
+    {
+        if (isset($this->childrenAttributes[$name])) {
+            return $this->childrenAttributes[$name];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return \Knp\Menu\ItemInterface
+     */
+    public function setChildrenAttribute($name, $value)
+    {
+        $this->childrenAttributes[$name] = $value;
 
         return $this;
     }

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -110,7 +110,14 @@ class ListRenderer extends Renderer implements RendererInterface
 
         // renders the embedded ul if there are visible children
         if ($item->hasChildren() && 0 !== $options['depth'] && $item->getDisplayChildren()) {
-            $html .= $this->format('<ul'.$this->renderHtmlAttributes(array('class' => 'menu_level_'.$item->getLevel())).'>', 'ul', $item->getLevel());
+
+            $childrenClass = ($item->getChildrenAttribute('class')) ? explode(' ', $item->getChildrenAttribute('class')) : array();
+            $childrenClass[] = 'menu_level_'.$item->getLevel();
+
+            $childrenAttributes = $item->getChildrenAttributes();
+            $childrenAttributes['class'] = implode(' ', $childrenClass);
+
+            $html .= $this->format('<ul'.$this->renderHtmlAttributes($childrenAttributes).'>', 'ul', $item->getLevel());
             $html .= $this->renderChildren($item, $options);
             $html .= $this->format('</ul>', 'ul', $item->getLevel());
         }

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -62,7 +62,10 @@
         <span{{ _self.attributes(item.labelAttributes) }}>{{ block('label') }}</span>
         {%- endif %}
         {%- if item.hasChildren and options.depth is not sameas(0) and item.displayChildren %}
-            <ul{{ _self.attributes({'class': 'menu_level_' ~ item.level }) }}>
+            {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
+            {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
+            {%- set childrenAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
+            <ul{{ _self.attributes(childrenAttributes) }}>
                 {{ block('children') }}
             </ul>
         {%- endif %}

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -88,6 +88,23 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $menu->getLinkAttribute('title', 'foobar'));
     }
 
+    public function testChildrenAttributes()
+    {
+        $attributes = array('class' => 'test_class', 'title' => 'Test title');
+        $menu = $this->createMenu();
+        $menu->setChildrenAttributes($attributes);
+        $this->assertEquals($attributes, $menu->getChildrenAttributes());
+    }
+
+    public function testDefaultChildrenAttribute()
+    {
+        $menu = $this->createMenu();
+        $menu->setChildrenAttribute('class', 'test_class');
+        $this->assertEquals('test_class', $menu->getChildrenAttribute('class'));
+        $this->assertNull($menu->getChildrenAttribute('title'));
+        $this->assertEquals('foobar', $menu->getChildrenAttribute('title', 'foobar'));
+    }
+
     public function testLabelAttributes()
     {
         $attributes = array('class' => 'test_class', 'title' => 'Test title');

--- a/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
@@ -148,6 +148,38 @@ abstract class AbstractRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($rendered, $this->renderer->renderItem($about));
     }
 
+    public function testRenderChildrenWithAttributes()
+    {
+        $about = $this->menu->addChild('About');
+        $about->addChild('Us');
+        $about->setChildrenAttribute('title', 'About page');
+
+        $rendered = '<li class="last"><span>About</span><ul title="About page" class="menu_level_1"><li class="first last"><span>Us</span></li></ul></li>';
+        $this->assertEquals($rendered, $this->renderer->renderItem($about));
+    }
+
+    public function testRenderChildrenWithEmptyAttributes()
+    {
+        $about = $this->menu->addChild('About');
+        $about->addChild('Us');
+        $about->setChildrenAttribute('title', '');
+        $about->setChildrenAttribute('rel', null);
+        $about->setChildrenAttribute('target', false);
+
+        $rendered = '<li class="last"><span>About</span><ul title="" class="menu_level_1"><li class="first last"><span>Us</span></li></ul></li>';
+        $this->assertEquals($rendered, $this->renderer->renderItem($about));
+    }
+
+    public function testRenderChildrenWithSpecialAttributes()
+    {
+        $about = $this->menu->addChild('About');
+        $about->addChild('Us');
+        $about->setChildrenAttribute('title', true);
+
+        $rendered = '<li class="last"><span>About</span><ul title="title" class="menu_level_1"><li class="first last"><span>Us</span></li></ul></li>';
+        $this->assertEquals($rendered, $this->renderer->renderItem($about));
+    }
+
     public function testRenderLabelWithAttributes()
     {
         $about = $this->menu->addChild('About');


### PR DESCRIPTION
This allows custom styling of &lt;ul&gt; elements for submenus inside of &lt;li&gt;s.
