### PR TITLE
fix bug when create from array

### DIFF
--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -62,11 +62,12 @@ class MenuFactory implements FactoryInterface
      * The source is an array of data that should match the output from MenuItem->toArray().
      *
      * @param  array $data The array of data to use as a source for the menu tree
+     * @param  string $name The name of the source (if not set in data['name'])
      * @return MenuItem
      */
-    public function createFromArray(array $data)
+    public function createFromArray(array $data, $name = null)
     {
-        $name = isset($data['name']) ? $data['name'] : null;
+        $name = isset($data['name']) ? $data['name'] : $name;
         if (isset($data['children'])) {
             $children = $data['children'];
             unset($data['children']);
@@ -75,8 +76,8 @@ class MenuFactory implements FactoryInterface
         }
 
         $item = $this->createItem($name, $data);
-        foreach ($children as $child) {
-            $item->addChild($this->createFromArray($child));
+        foreach ($children as $name => $child) {
+            $item->addChild($this->createFromArray($child, $name));
         }
 
         return $item;


### PR DESCRIPTION
Hi, 

Today I've used KnpMenu for the first time, and try to load menu from yaml file.
But I encoutered a problem : if no attribute "name" is set for each item, only the last one appears in my menu. So why not use the "key" of item in name ...

My yaml looks like this : 

``` yaml
menus.backend_main:
    name:               backend_main
    children:
      home:
        label:          nav.home
        route:            
        children:
          activities:
            label:      nav.cms.last_activities
            route:        
          sections:
            label:      nav.cms.sections
            route:
```

I'm an absolute beginner on github, pull requests and so on.
So my apologies if I do not the right way ;)

Baptiste
