### PR TITLE
Made the default options configurable for the TwigRenderer

### DIFF
--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -12,19 +12,26 @@ class TwigRenderer implements RendererInterface
      * @var \Twig_Environment
      */
     private $environment;
-    private $defaultTemplate;
-    private $renderCompressed = false;
+    private $defaultOptions;
 
     /**
      * @param \Twig_Environment $environment
      * @param string $template
-     * @param boolean $renderCompressed
+     * @param array $defaultOptions
      */
-    public function __construct(\Twig_Environment $environment, $template, $renderCompressed = false)
+    public function __construct(\Twig_Environment $environment, $template, array $defaultOptions = array())
     {
         $this->environment = $environment;
-        $this->defaultTemplate = $template;
-        $this->renderCompressed = $renderCompressed;
+        $this->defaultOptions = array_merge(array(
+            'depth' => null,
+            'currentAsLink' => true,
+            'currentClass' => 'current',
+            'ancestorClass' => 'current_ancestor',
+            'firstClass' => 'first',
+            'lastClass' => 'last',
+            'template' => $template,
+            'compressed' => false,
+        ), $defaultOptions);
     }
 
     /**
@@ -36,7 +43,7 @@ class TwigRenderer implements RendererInterface
      */
     public function render(ItemInterface $item, array $options = array())
     {
-        $options = array_merge($this->getDefaultOptions(), $options);
+        $options = array_merge($this->defaultOptions, $options);
 
         $template = $options['template'];
         if (!$template instanceof \Twig_Template) {
@@ -51,19 +58,5 @@ class TwigRenderer implements RendererInterface
         $html = ob_get_clean();
 
         return $html;
-    }
-
-    private function getDefaultOptions()
-    {
-        return array(
-            'depth' => null,
-            'currentAsLink' => true,
-            'currentClass' => 'current',
-            'ancestorClass' => 'current_ancestor',
-            'firstClass' => 'first',
-            'lastClass' => 'last',
-            'template' => $this->defaultTemplate,
-            'compressed' => $this->renderCompressed,
-        );
     }
 }

--- a/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
@@ -15,7 +15,7 @@ class TwigRendererTest extends AbstractRendererTest
         }
         $loader = new \Twig_Loader_Filesystem(__DIR__.'/../../../../../src/Knp/Menu/Resources/views');
         $environment = new \Twig_Environment($loader);
-        $renderer = new TwigRenderer($environment, 'knp_menu.html.twig', true);
+        $renderer = new TwigRenderer($environment, 'knp_menu.html.twig', array('compressed' => true));
 
         return $renderer;
     }


### PR DESCRIPTION
This makes the default options configurable for the TwigRenderer, thus making #27 obsolete (/cc @havvg).

I kept the constructor argument for the default template as passing it is required. However, there is a small BC break for people using  the third parameter to render the menu compressed by default. As all options are configurable now, it should be done through the option array. Keeping a dedicated parameter for it would be redundant. Is it OK for you ?
