### PR TITLE
[WIP] [Outdated] Added a first implementation of a BreadcrumbRenderer

### DIFF
--- a/tests/Knp/Menu/Tests/Renderer/BreadcrumbRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/BreadcrumbRendererTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Knp\Menu\Tests\Renderer;
+
+use Knp\Menu\Renderer\BreadcrumbRenderer;
+use Knp\Menu\Tests\TestCase;
+
+class BreadcrumbRendererTest extends TestCase
+{
+    public function testBreadcrumbRendering()
+    {
+        $renderer = new BreadcrumbRenderer(array('compressed' => true));
+
+        $expected = '<ul><li>Root li</li><li>Parent 1</li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testAdditionalPath()
+    {
+        $renderer = new BreadcrumbRenderer(array('compressed' => true));
+
+        $expected = '<ul><li>Root li</li><li>Parent 1</li><li>Child 1</li><li><a href="http://example.com">Foo</a></li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1, array('additional_path' => array('Foo' => 'http://example.com'))));
+    }
+
+    public function testCurrentLink()
+    {
+        $this->pt1->setUri('foobar')->setCurrent(true);
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true));
+
+        $expected = '<ul><li>Root li</li><li class="current"><a href="foobar">Parent 1</a></li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testCurrentNoLink()
+    {
+        $this->pt1->setUri('foobar')->setCurrent(true);
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true, 'current_as_link' => false));
+
+        $expected = '<ul><li>Root li</li><li class="current">Parent 1</li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testCurrentCustomClass()
+    {
+        $this->pt1->setCurrent(true);
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true, 'current_class' => 'foo'));
+
+        $expected = '<ul><li>Root li</li><li class="foo">Parent 1</li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testEscapedLabel()
+    {
+        $this->pt1->setExtra('safe_label', true)->setLabel('<strong>Foo</strong>');
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true));
+
+        $expected = '<ul><li>Root li</li><li>&lt;strong&gt;Foo&lt;/strong&gt;</li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testUnsafeLabel()
+    {
+        $this->pt1->setLabel('<strong>Foo</strong>');
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true, 'allow_safe_labels' => true));
+
+        $expected = '<ul><li>Root li</li><li>&lt;strong&gt;Foo&lt;/strong&gt;</li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testSafeLabel()
+    {
+        $this->pt1->setExtra('safe_label', true)->setLabel('<strong>Foo</strong>');
+
+        $renderer = new BreadcrumbRenderer(array('compressed' => true, 'allow_safe_labels' => true));
+
+        $expected = '<ul><li>Root li</li><li><strong>Foo</strong></li><li>Child 1</li></ul>';
+
+        $this->assertEquals($expected, $renderer->render($this->ch1));
+    }
+
+    public function testPrettyRendering()
+    {
+        $renderer = new BreadcrumbRenderer();
+
+        $rendered = <<<HTML
+<ul>
+  <li>
+    Root li
+  </li>
+  <li>
+    Parent 1
+  </li>
+  <li>
+    Child 1
+  </li>
+</ul>
+
+HTML;
+
+        $this->assertEquals($rendered, $renderer->render($this->ch1));
+    }
+}


### PR DESCRIPTION
This is a WIP about #24 meant for discussion.

This implementation uses the `getBreadcrumbsArray` method, making it easy to append additional stuff at the end of the breadcrumb. However, it means that you are limited when rendering each item as you only have the label and the uri. The other solution would be to build an array of items or to call getParent each time, but it would make it harder to pass additional paths as it would require building items for them (in this regards, an array of items would be easier than calling `getParent` during the rendering though as we don't need to add the new items in the existing menu tree).

To use it, you need to call the `knp_menu_render` method with the item corresponding to the end of the breadcrumbs, i.e. the item for which the breadcrumb is rendered (except the additional path of course). This is a good use case to [get an item by path in the tree](https://github.com/KnpLabs/KnpMenu/blob/master/doc/02-Twig-Integration.markdown#get-item-by-path)
