### PR TITLE
Added a way to mark a label as safe for the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.0 (2012-XX-XX)
 
+* Added a way to mark a label as safe
 * Refactored the ListRenderer to be consistent with the TwigRenderer and provide the same extension points
 * Added a way to attach extra data to an item
 * Removed unnecessary optimization in the TwigRenderer

--- a/doc/01-Basic-Menus.markdown
+++ b/doc/01-Basic-Menus.markdown
@@ -236,6 +236,13 @@ the second argument to the `render()` method:
 * `firstClass` (default: `first`)
 * `lastClass` (default:  `last`)
 * `compressed` (default: `false`)
+* `allow_safe_labels` (default: `false`)
+
+>**NOTE**
+>When setting the `allow_safe_labels` option to `true`, you can specify that
+>a label should not be escaped by the renderer by adding the `safe_label`
+>extra in the item. Use it with caution as it can create some XSS holes in
+>your application if the label is coming from the user.
 
 The Current Menu Item
 ---------------------

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -25,6 +25,7 @@ class ListRenderer extends Renderer implements RendererInterface
             'firstClass' => 'first',
             'lastClass' => 'last',
             'compressed' => false,
+            'allow_safe_labels' => false,
         ), $defaultOptions);
 
         parent::__construct($charset);
@@ -186,6 +187,10 @@ class ListRenderer extends Renderer implements RendererInterface
 
     protected function renderLabel(ItemInterface $item, array $options)
     {
+        if ($options['allow_safe_labels'] && $item->getExtra('safe_label', false)) {
+            return $item->getLabel();
+        }
+
         return $this->escape($item->getLabel());
     }
 

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -31,6 +31,7 @@ class TwigRenderer implements RendererInterface
             'lastClass' => 'last',
             'template' => $template,
             'compressed' => false,
+            'allow_safe_labels' => false,
         ), $defaultOptions);
     }
 

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -80,4 +80,4 @@
 
 {% block spanElement %}<span{{ _self.attributes(item.labelAttributes) }}>{{ block('label') }}</span>{% endblock %}
 
-{% block label %}{{ item.label }}{% endblock %}
+{% block label %}{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|raw }}{% else %}{{ item.label }}{% endif %}{% endblock %}

--- a/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
@@ -221,6 +221,28 @@ abstract class AbstractRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($rendered, $this->renderer->render($menu));
     }
 
+    public function testRenderEscapedLabel()
+    {
+        $menu = new MenuItem('test', new MenuFactory());
+        $menu->addChild('About', array('label' => 'Encode " me'));
+        $menu->addChild('Safe', array('label' => 'Encode " me again', 'extras' => array('safe_label' => true)));
+        $menu->addChild('Escaped', array('label' => 'Encode " me too', 'extras' => array('safe_label' => false)));
+
+        $rendered = '<ul><li class="first"><span>Encode &quot; me</span></li><li><span>Encode &quot; me again</span></li><li class="last"><span>Encode &quot; me too</span></li></ul>';
+        $this->assertEquals($rendered, $this->renderer->render($menu));
+    }
+
+    public function testRenderSafeLabel()
+    {
+        $menu = new MenuItem('test', new MenuFactory());
+        $menu->addChild('About', array('label' => 'Encode " me'));
+        $menu->addChild('Safe', array('label' => 'Encode " me again', 'extras' => array('safe_label' => true)));
+        $menu->addChild('Escaped', array('label' => 'Encode " me too', 'extras' => array('safe_label' => false)));
+
+        $rendered = '<ul><li class="first"><span>Encode &quot; me</span></li><li><span>Encode " me again</span></li><li class="last"><span>Encode &quot; me too</span></li></ul>';
+        $this->assertEquals($rendered, $this->renderer->render($menu, array('allow_safe_labels' => true)));
+    }
+
     public function testRenderWholeMenu()
     {
         $rendered = '<ul class="root"><li class="first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';


### PR DESCRIPTION
This adds a way to mark a label as safe, to avoid the escaping in the renderer. This is disabled by default so that people using it need to be conscious about it (as it can create some XSS issue if they use it with a label entered by the user).

Related to #23 and #38

/cc @mcal @xantos05 and @ysarazin
