### PR TITLE
Keep route and routeParameters informations in the item menu

### DIFF
--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -33,6 +33,16 @@ class MenuItem implements ItemInterface
      */
     protected $labelAttributes = array();
     /**
+     * Route use by the uri
+     * @var string
+     */
+    protected $route = null;
+    /**
+     * Route parameters use by the uri
+     * @var string
+     */
+    protected $routeParameters = array();
+    /**
      * Uri to use in the anchor tag
      * @var string
      */
@@ -149,6 +159,52 @@ class MenuItem implements ItemInterface
         return $this;
     }
 
+    /**
+     * Get the route for a menu item
+     *
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * Set the route for a menu item
+     *
+     * @param  string $route The route to set on this menu item
+     * @return ItemInterface
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+
+        return $this;
+    }
+
+    /**
+     * Get route parameters for a menu item
+     *
+     * @return string
+     */
+    public function getRouteParameters()
+    {
+        return $this->routeParameters;
+    }
+
+    /**
+     * Set the route parameters for a menu item
+     *
+     * @param  string $routeParameters Route parameters to set on this menu item
+     * @return ItemInterface
+     */
+    public function setRouteParameters($routeParameters)
+    {
+        $this->routeParameters = $routeParameters;
+
+        return $this;
+    }
+    
     /**
      * Get the uri for a menu item
      *
@@ -1177,6 +1233,8 @@ class MenuItem implements ItemInterface
         $array = array(
             'name' => $this->name,
             'label' => $this->label,
+            'route' => $this->route,
+            'routeParameters' => $this->routeParameters,
             'uri' => $this->uri,
             'attributes' => $this->attributes,
             'labelAttributes' => $this->labelAttributes,

--- a/src/Knp/Menu/Silex/RouterAwareFactory.php
+++ b/src/Knp/Menu/Silex/RouterAwareFactory.php
@@ -3,6 +3,7 @@
 namespace Knp\Menu\Silex;
 
 use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -19,12 +20,45 @@ class RouterAwareFactory extends MenuFactory
 
     public function createItem($name, array $options = array())
     {
+        $item = new MenuItem($name, $this);
+        
         if (!empty($options['route'])) {
             $params = isset($options['routeParameters']) ? $options['routeParameters'] : array();
             $absolute = isset($options['routeAbsolute']) ? $options['routeAbsolute'] : false;
             $options['uri'] = $this->generator->generate($options['route'], $params, $absolute);
         }
+        
+        $options = array_merge(
+            array(
+                'route' => null,
+                'routeParameters' => array(),
+                'uri' => null,
+                'label' => null,
+                'attributes' => array(),
+                'linkAttributes' => array(),
+                'childrenAttributes' => array(),
+                'labelAttributes' => array(),
+                'extras' => array(),
+                'display' => true,
+                'displayChildren' => true,
+            ),
+            $options
+        );        
 
-        return parent::createItem($name, $options);
+        $item
+            ->setRoute($options['route'])
+            ->setRouteParameters($options['routeParameters'])
+            ->setUri($options['uri'])
+            ->setLabel($options['label'])
+            ->setAttributes($options['attributes'])
+            ->setLinkAttributes($options['linkAttributes'])
+            ->setChildrenAttributes($options['childrenAttributes'])
+            ->setLabelAttributes($options['labelAttributes'])
+            ->setExtras($options['extras'])
+            ->setDisplay($options['display'])
+            ->setDisplayChildren($options['displayChildren'])
+        ;
+
+        return $item;
     }
 }

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -207,6 +207,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
             array(
                 'name' => 'test_menu',
                 'label' => null,
+                'route' => null,
+                'routeParameters' => array(),
                 'uri' => 'homepage',
                 'attributes' => array(),
                 'labelAttributes' => array(),
@@ -219,6 +221,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
                     'jack' => array(
                         'name' => 'jack',
                         'label' => null,
+                        'route' => null,
+                        'routeParameters' => array(),
                         'uri' => 'http://php.net',
                         'attributes' => array(),
                         'labelAttributes' => array(),
@@ -231,6 +235,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
                             'john' => array(
                                 'name' => 'john',
                                 'label' => null,
+                                'route' => null,
+                                'routeParameters' => array(),
                                 'uri' => null,
                                 'attributes' => array(),
                                 'labelAttributes' => array(),
@@ -246,6 +252,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
                     'joe' => array(
                         'name' => 'joe',
                         'label' => 'test',
+                        'route' => null,
+                        'routeParameters' => array(),
                         'uri' => null,
                         'attributes' => array('class' => 'leaf'),
                         'labelAttributes' => array('class' => 'center'),
@@ -274,6 +282,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
             array(
                 'name' => 'test_menu',
                 'label' => null,
+                'route' => null,
+                'routeParameters' => array(),
                 'uri' => 'homepage',
                 'attributes' => array(),
                 'labelAttributes' => array(),
@@ -286,6 +296,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
                     'jack' => array(
                         'name' => 'jack',
                         'label' => null,
+                        'route' => null,
+                        'routeParameters' => array(),
                         'uri' => 'http://php.net',
                         'attributes' => array(),
                         'labelAttributes' => array(),
@@ -298,6 +310,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
                     'joe' => array(
                         'name' => 'joe',
                         'label' => 'test',
+                        'route' => null,
+                        'routeParameters' => array(),
                         'uri' => null,
                         'attributes' => array('class' => 'leaf'),
                         'labelAttributes' => array('class' => 'center'),
@@ -323,6 +337,8 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
             array(
                 'name' => 'test_menu',
                 'label' => null,
+                'route' => null,
+                'routeParameters' => array(),
                 'uri' => 'homepage',
                 'attributes' => array(),
                 'labelAttributes' => array(),


### PR DESCRIPTION
It may be useful to keep them sometimes, to create links with variable parameters.
