### PR TITLE
Pass options to get method to be able to see the options in a menu provider

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -87,7 +87,7 @@ class Helper
                 $menu = array_shift($path);
             }
 
-            $menu = $this->get($menu, $path);
+            $menu = $this->get($menu, $path, $options);
         }
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);


### PR DESCRIPTION
I would like to be able to see the options in a custom menu provider, but the options are currently not passed on to the get method ...
