### PR TITLE
Symfony2 gets confused by the @homepage being in a seperate line and throws an annotation error 

### DIFF
--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -818,8 +818,7 @@ class MenuItem implements ItemInterface
      * The subItem can be one of the following forms
      *   * 'subItem'
      *   * Knp\Menu\ItemInterface object
-     *   * array('subItem' => '
-     * @homepage')
+     *   * array('subItem' => '@homepage')
      *   * array('subItem1', 'subItem2')
      *   * array(array('label' => 'subItem1', 'url' => '@homepage'), array('label' => 'subItem2'))
      *


### PR DESCRIPTION
This commit fixes that.
