### PR TITLE
Add Access methods on TwigRenderer

### DIFF
--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -57,4 +57,19 @@ class TwigRenderer implements RendererInterface
 
         return $html;
     }
+
+    public function getEnvironment()
+    {
+        return $this->environment;
+    } 
+
+    public function getMatcher()
+    {
+        return $this->matcher;
+    }
+
+    public function getDefaultOptions()
+    {
+        return $this->defaultOptions;
+    } 
 }


### PR DESCRIPTION
I searched any issue about this "problem" but I not found. 
I'm extending a Renderer, but my class CloudRenderer is very similar to TwigRenderer, so I extends this class. But, when I would rewrite the render method, I dont had access to defaultOptions, for example. I think that their methods will be needs in the future.
