### PR TITLE
Output children if ancestor is current (or child is)

### DIFF
--- a/doc/01-Basic-Menus.markdown
+++ b/doc/01-Basic-Menus.markdown
@@ -219,6 +219,11 @@ $renderer->render($menu);
 // render everything except for Home AND its children
 $menu['Home']->setDisplay(false);
 $renderer->render($menu);
+
+// only render children if the ancestor 'Home'
+// is current or the child itself is current
+$menu['Home']->setDisplayChildrenIfAncestorCurrent(true);
+
 ```
 
 Using the above controls, you can specify exactly which part of your menu

--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -60,6 +60,13 @@ class MenuItem implements ItemInterface
     protected $displayChildren = true;
 
     /**
+     * Whether children of an item are only displayed when the item is current
+     * or the child item is current
+     * @var boolean
+     */
+    protected $displayChildrenIfAncestorCurrent = false;
+
+    /**
      * Child items
      * @var ItemInterface[]
      */
@@ -304,6 +311,18 @@ class MenuItem implements ItemInterface
     public function setDisplayChildren($bool)
     {
         $this->displayChildren = (bool) $bool;
+
+        return $this;
+    }
+
+    public function getDisplayChildrenIfAncestorCurrent()
+    {
+        return $this->displayChildrenIfAncestorCurrent;
+    }
+
+    public function setDisplayChildrenIfAncestorCurrent($bool)
+    {
+        $this->displayChildrenIfAncestorCurrent = (bool) $bool;
 
         return $this;
     }

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -71,7 +71,7 @@
         {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
         {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
         {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
-        {% if matcher.isCurrent(item) or (item.displayChildrenIfAncestorCurrent and matcher.isAncestor(item)) %}
+        {% if not item.displayChildrenIfAncestorCurrent or (matcher.isCurrent(item) or matcher.isAncestor(item)) %}
             {{ block('list') }}
         {% endif %}
     </li>

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -71,7 +71,9 @@
         {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
         {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
         {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
-        {{ block('list') }}
+        {% if matcher.isCurrent(item) or (item.displayChildrenIfAncestorCurrent and matcher.isAncestor(item)) %}
+            {{ block('list') }}
+        {% endif %}
     </li>
 {% endif %}
 {% endblock %}

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -155,6 +155,14 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $menu->getDisplayChildren());
     }
 
+    public function testShowChildrenIfAncestorCurrent()
+    {
+        $menu = $this->createMenu();
+        $this->assertEquals(false, $menu->getDisplayChildrenIfAncestorCurrent());
+        $menu->setDisplayChildrenIfAncestorCurrent(true);
+        $this->assertEquals(true, $menu->getDisplayChildrenIfAncestorCurrent());
+    }
+
     public function testParent()
     {
         $menu = $this->createMenu();


### PR DESCRIPTION
Adds a property and methods to add ability to only output children of 
 a menu item, if the item itself, or the ancestor is 'current'.

Closes #84
