### PR TITLE
Allow route parameters don't be of same type

### DIFF
--- a/src/Knp/Menu/Silex/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Silex/Voter/RouteVoter.php
@@ -41,7 +41,7 @@ class RouteVoter implements VoterInterface
 
             if (isset($parameters[$route])) {
                 foreach ($parameters[$route] as $name => $value) {
-                    if ($this->request->attributes->get($name) !== $value) {
+                    if ($this->request->attributes->get($name) != $value) {
                         return null;
                     }
                 }

--- a/tests/Knp/Menu/Tests/Silex/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Silex/Voter/RouteVoterTest.php
@@ -92,6 +92,17 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                 'foo', array('foo' => array('1' => 'bar')),
                 true
             ),
+    		'same single route with same type parameters' => array(
+                'foo', array('1' => 2),
+                'foo', array('foo' => array('1' => 2)),
+                true
+            ),
+            'same single route with different type parameters' => array(
+                'foo', array('1' => 2),
+                'foo', array('foo' => array('1' => '2')),
+                true
+            ),
+            
         );
     }
 }


### PR DESCRIPTION
Since `Symfony\Component\HttpFoundation\Request->parameters` isn't type aware numeric keys aren't matched when added route to child contains an actual integer.
