### PR TITLE
Pass options through to the get() method

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -91,7 +91,7 @@ class Helper
                 $menu = array_shift($path);
             }
 
-            $menu = $this->get($menu, $path);
+            $menu = $this->get($menu, $path, $options);
         }
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);


### PR DESCRIPTION
$options were not being passed through which meant it wasn't eventually being passed through to the Builder.

Another workaround here: https://groups.google.com/forum/#!topic/symfony2/p10iA-57i4s
