### PR TITLE
Don't override existing extras when building item

### DIFF
--- a/src/Knp/Menu/Factory/CoreExtension.php
+++ b/src/Knp/Menu/Factory/CoreExtension.php
@@ -50,10 +50,29 @@ class CoreExtension implements ExtensionInterface
             ->setLinkAttributes($options['linkAttributes'])
             ->setChildrenAttributes($options['childrenAttributes'])
             ->setLabelAttributes($options['labelAttributes'])
-            ->setExtras($options['extras'])
             ->setCurrent($options['current'])
             ->setDisplay($options['display'])
             ->setDisplayChildren($options['displayChildren'])
         ;
+
+        $this->buildExtras( $item, $options );
+    }
+
+    /**
+     * Configures the newly created item's extras
+     * Extras are processed one by one in order not to reset values set by other extensions
+     *
+     * @param ItemInterface $item
+     * @param array         $options
+     */
+    private function buildExtras(ItemInterface $item, array $options)
+    {
+        if( !empty( $options['extras'] ) )
+        {
+            foreach( $options['extras'] as $key => $value )
+            {
+                $item->setExtra( $key, $value );
+            }
+        }
     }
 }

--- a/tests/Knp/Menu/Tests/Factory/CoreExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Factory/CoreExtensionTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author: bchoquet
+ */
+
+namespace Knp\Menu\Tests\Factory;
+
+
+use Knp\Menu\Factory\CoreExtension;
+use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
+
+class CoreExtensionTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testBuildItemsSetsExtras()
+    {
+        $item = $this->createItem( 'test' );
+        $item->setExtra( 'test', 'original value' );
+        $options = array(
+            'extras' => array(
+                'test1' => 'options value 1',
+                'test2' => 'options value 2',
+            )
+        );
+
+        $extension = $this->getExtension();
+        $extension->buildItem( $item, $options );
+
+        $extras = $item->getExtras();
+
+        $this->assertEquals( 3, count( $extras ) );
+
+        $this->assertArrayHasKey( 'test1', $extras );
+        $this->assertEquals( 'options value 1', $item->getExtra( 'test1' ) );
+
+        $this->assertArrayHasKey( 'test2', $extras );
+        $this->assertEquals( 'options value 2', $item->getExtra( 'test2' ) );
+    }
+
+    public function testBuildItemDoesNotOverrideExistingExtras()
+    {
+        $item = $this->createItem( 'test' );
+        $item->setExtra( 'test', 'original value' );
+        $options = array(
+            'extras' => array(
+                'test' => 'options value',
+            )
+        );
+
+        $extension = $this->getExtension();
+        $extension->buildItem( $item, $options );
+
+        $this->assertArrayHasKey( 'test', $item->getExtras() );
+        $this->assertEquals( 'original value', $item->getExtra( 'test' ) );
+    }
+
+    private function getExtension()
+    {
+        return new CoreExtension();
+    }
+
+    private function createItem( $name )
+    {
+        $factory = new MenuFactory();
+        $item = new MenuItem( $name, $factory );
+
+        return $item;
+    }
+}
+ 


### PR DESCRIPTION
Since CoreExtension is loaded with a low priority in MenuFactory, prior extensions setting extras at item building time currently get their values overriden.
