### PR TITLE
updated Twig Helper

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -91,7 +91,7 @@ class Helper
                 $menu = array_shift($path);
             }
 
-            $menu = $this->get($menu, $path);
+            $menu = $this->get($menu, $path, $options);
         }
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);


### PR DESCRIPTION
Why does the helper not pass on the options supplied to the render method to the helper's get method? Passing the options allows a lot of flexibility when building a menu. I cannot see a reason why these options should not be passed to the get method.
