### PR TITLE
Twig's Helper.php update

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -91,7 +91,7 @@ class Helper
                 $menu = array_shift($path);
             }
 
-            $menu = $this->get($menu, $path);
+            $menu = $this->get($menu, $path, $options);
         }
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);


### PR DESCRIPTION
Pass the $options to the menuProvider so it is possible to process the options in the menu provider. Useful in cases where extra options needs to be passed to the custom menu provider.
