### PR TITLE
[WIP] Breadcrumb renderer

### DIFF
--- a/src/Knp/Menu/Renderer/BaseRenderer.php
+++ b/src/Knp/Menu/Renderer/BaseRenderer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Knp\Menu\Renderer;
+
+use Knp\Menu\ItemInterface;
+
+abstract class BaseRenderer implements RendererInterface
+{
+    protected $defaultOptions;
+
+    public function __construct($defaultOptions)
+    {
+        $this->defaultOptions = array_merge(array(
+            'depth' => null,
+            'matchingDepth' => null,
+            'currentAsLink' => true,
+            'currentClass' => 'current',
+            'ancestorClass' => 'current_ancestor',
+            'firstClass' => 'first',
+            'lastClass' => 'last',
+            'compressed' => false,
+            'allow_safe_labels' => false,
+            'clear_matcher' => true,
+            'leaf_class' => null,
+            'branch_class' => null,
+        ), $defaultOptions);
+    }
+
+    public abstract function render(ItemInterface $item, array $options = array());
+}

--- a/src/Knp/Menu/Renderer/BreadcrumbRenderer.php
+++ b/src/Knp/Menu/Renderer/BreadcrumbRenderer.php
@@ -10,7 +10,6 @@ use Knp\Menu\Util\MenuManipulator;
  */
 class BreadcrumbRenderer extends Renderer implements RendererInterface
 {
-    private $defaultOptions;
     private $itemManipulator;
 
     /**
@@ -20,17 +19,13 @@ class BreadcrumbRenderer extends Renderer implements RendererInterface
      */
     public function __construct(MenuManipulator $itemManipulator, array $defaultOptions = array(), $charset = null)
     {
-        $this->defaultOptions = array_merge(array(
-            'current_as_link' => true,
-            'current_class' => 'current',
+        $this->itemManipulator = $itemManipulator;
+        $defaultOptions = array_merge(array(
             'additional_path' => null,
-            'compressed' => false,
-            'allow_safe_labels' => false,
             'root_attributes' => array(),
         ), $defaultOptions);
-        $this->itemManipulator = $itemManipulator;
 
-        parent::__construct($charset);
+        parent::__construct($defaultOptions, $charset);
     }
 
     /**
@@ -97,13 +92,13 @@ class BreadcrumbRenderer extends Renderer implements RendererInterface
     protected function renderItem($label, $uri, array $options, ItemInterface $item = null)
     {
         $isCurrent = null !== $item && $item->isCurrent();
-        $attributes = $isCurrent ? array('class' => $options['current_class']) : array();
+        $attributes = $isCurrent ? array('class' => $options['currentClass']) : array();
 
         // opening li tag
         $html = $this->format('<li'.$this->renderHtmlAttributes($attributes).'>', 'li', 1, $options);
 
         // render the text/link inside the li tag
-        if (null === $uri || ($isCurrent && !$options['current_as_link'])) {
+        if (null === $uri || ($isCurrent && !$options['currentAsLink'])) {
             $content = $this->renderLabel($label, $options, $item);
         } else {
             $content = sprintf('<a href="%s">%s</a>', $this->escape($uri), $this->renderLabel($label, $options, $item));

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -8,10 +8,9 @@ use Knp\Menu\Matcher\MatcherInterface;
 /**
  * Renders MenuItem tree as unordered list
  */
-class ListRenderer extends Renderer implements RendererInterface
+class ListRenderer extends Renderer
 {
     protected $matcher;
-    protected $defaultOptions;
 
     /**
      * @param MatcherInterface $matcher
@@ -21,22 +20,8 @@ class ListRenderer extends Renderer implements RendererInterface
     public function __construct(MatcherInterface $matcher, array $defaultOptions = array(), $charset = null)
     {
         $this->matcher = $matcher;
-        $this->defaultOptions = array_merge(array(
-            'depth' => null,
-            'matchingDepth' => null,
-            'currentAsLink' => true,
-            'currentClass' => 'current',
-            'ancestorClass' => 'current_ancestor',
-            'firstClass' => 'first',
-            'lastClass' => 'last',
-            'compressed' => false,
-            'allow_safe_labels' => false,
-            'clear_matcher' => true,
-            'leaf_class' => null,
-            'branch_class' => null,
-        ), $defaultOptions);
 
-        parent::__construct($charset);
+        parent::__construct($defaultOptions, $charset);
     }
 
     public function render(ItemInterface $item, array $options = array())

--- a/src/Knp/Menu/Renderer/Renderer.php
+++ b/src/Knp/Menu/Renderer/Renderer.php
@@ -6,18 +6,20 @@ if (!defined('ENT_SUBSTITUTE')) {
     define('ENT_SUBSTITUTE', 8);
 }
 
-abstract class Renderer
+abstract class Renderer extends BaseRenderer
 {
     protected $charset = 'UTF-8';
 
     /**
      * @param string $charset
      */
-    public function __construct($charset = null)
+    public function __construct($defaultOptions = array(), $charset = null)
     {
         if (null !== $charset) {
             $this->charset = (string) $charset;
         }
+
+        parent::__construct($defaultOptions);
     }
 
     /**

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -5,14 +5,13 @@ namespace Knp\Menu\Renderer;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 
-class TwigRenderer implements RendererInterface
+class TwigRenderer extends BaseRenderer
 {
     /**
      * @var \Twig_Environment
      */
     private $environment;
     private $matcher;
-    private $defaultOptions;
 
     /**
      * @param \Twig_Environment $environment
@@ -24,21 +23,12 @@ class TwigRenderer implements RendererInterface
     {
         $this->environment = $environment;
         $this->matcher = $matcher;
-        $this->defaultOptions = array_merge(array(
-            'depth' => null,
-            'matchingDepth' => null,
-            'currentAsLink' => true,
-            'currentClass' => 'current',
-            'ancestorClass' => 'current_ancestor',
-            'firstClass' => 'first',
-            'lastClass' => 'last',
-            'template' => $template,
-            'compressed' => false,
-            'allow_safe_labels' => false,
-            'clear_matcher' => true,
-            'leaf_class' => null,
-            'branch_class' => null,
+
+        $defaultOptions = array_merge(array(
+            'template' => $template
         ), $defaultOptions);
+
+        parent::__construct($defaultOptions);
     }
 
     public function render(ItemInterface $item, array $options = array())

--- a/tests/Knp/Menu/Tests/Renderer/BreadcrumbRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/BreadcrumbRendererTest.php
@@ -41,7 +41,7 @@ class BreadcrumbRendererTest extends TestCase
     {
         $this->pt1->setUri('foobar')->setCurrent(true);
 
-        $renderer = new BreadcrumbRenderer(new MenuManipulator, array('compressed' => true, 'current_as_link' => false));
+        $renderer = new BreadcrumbRenderer(new MenuManipulator, array('compressed' => true, 'currentAsLink' => false));
 
         $expected = '<ul><li>Root li</li><li class="current">Parent 1</li><li>Child 1</li></ul>';
 
@@ -52,7 +52,7 @@ class BreadcrumbRendererTest extends TestCase
     {
         $this->pt1->setCurrent(true);
 
-        $renderer = new BreadcrumbRenderer(new MenuManipulator, array('compressed' => true, 'current_class' => 'foo'));
+        $renderer = new BreadcrumbRenderer(new MenuManipulator, array('compressed' => true, 'currentClass' => 'foo'));
 
         $expected = '<ul><li>Root li</li><li class="foo">Parent 1</li><li>Child 1</li></ul>';
 


### PR DESCRIPTION
This PR could be in 2.1 if it doesn't pass before the end of the beta.

And she needs:
- [ ] Documentation (build on #206)
- [ ] Twig adaptation
- [ ] Following other renderers (putting options in the abstract renderer class is a good idea IMO)

**Problem:** How to retrieve the current item without parsing the complete tree menu.
