### PR TITLE
We should be able to define an attribute with no value

### DIFF
--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -2,7 +2,9 @@
 
 {% macro attributes(attributes) %}
 {% for name, value in attributes %}
-    {%- if value is not none and value is not sameas(false) -%}
+    {%- if value is null -%}
+        {{- ' %s'|format(name)|raw -}}
+    {%- elseif value is not none and value is not sameas(false) -%}
         {{- ' %s="%s"'|format(name, value is sameas(true) ? name|e : value|e)|raw -}}
     {%- endif -%}
 {%- endfor -%}

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -64,6 +64,14 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($attributes, $menu->getAttributes());
     }
 
+    public function testNoneValueAttribute()
+    {
+        $attributes = array('itemscope' => null, 'itemtype' => 'http://data-vocabulary.org/Breadcrumb');
+        $menu = $this->createMenu();
+        $menu->setAttributes($attributes);
+        $this->assertEquals($attributes, $menu->getAttributes());
+    }
+
     public function testDefaultAttribute()
     {
         $menu = $this->createMenu(null, null, array('id' => 'test_id'));


### PR DESCRIPTION
Ex : "itemscope" to generate breadcrumb with microdatas for SEO:

```html
<ul class="list-inline breadcrumb">
<li  itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="first"> <a href="/">Homepage</a></li>
<li  itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="last"> <a href="/architects">Architects</a></li>
</ul>
```