### PR TITLE
render menu with custom provider by setting opions

### DIFF
--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -91,7 +91,7 @@ class Helper
                 $menu = array_shift($path);
             }
 
-            $menu = $this->get($menu, $path);
+            $menu = $this->get($menu, $path, $options);
         }
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);


### PR DESCRIPTION
If you create a custom menu provider and you want to call him with options from your twig template ; it doesn't work.

```
{{ knp_menu_render('menu', {'option': 'lorem ipsum dolor'}) }}
```

Maybye just forgot to pass `$options` in Knp\Menu\Twig\Helper at line 94.
