### PR TITLE
Add query parameters to route parameter test

### DIFF
--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -37,7 +37,6 @@ class RouteVoter implements VoterInterface
         }
 
         $routes = (array) $item->getExtra('routes', array());
-        $parameters = (array) $item->getExtra('routesParameters', array());
 
         foreach ($routes as $testedRoute) {
             if (is_string($testedRoute)) {
@@ -76,7 +75,7 @@ class RouteVoter implements VoterInterface
             return true;
         }
 
-        $routeParameters = $this->request->attributes->get('_route_params', array());
+        $routeParameters = $this->request->attributes->get('_route_params', array()) + $this->request->query->all();
 
         foreach ($testedRoute['parameters'] as $name => $value) {
             if (!isset($routeParameters[$name]) || $routeParameters[$name] !== (string) $value) {


### PR DESCRIPTION
If you add extra parameters to your uri `/{id}?foo=bar`, the `{id}` will match but the `foo=bar`  won't.

I also removed unused variable.
