### PR TITLE
Allow for more extendability

### DIFF
--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -13,12 +13,12 @@ class MenuFactory implements FactoryInterface
     /**
      * @var array[]
      */
-    private $extensions = array();
+    protected $extensions = array();
 
     /**
      * @var ExtensionInterface[]
      */
-    private $sorted;
+    protected $sorted;
 
     public function __construct()
     {
@@ -57,7 +57,7 @@ class MenuFactory implements FactoryInterface
      *
      * @return ExtensionInterface[]
      */
-    private function getExtensions()
+    protected function getExtensions()
     {
         if (null === $this->sorted) {
             krsort($this->extensions);


### PR DESCRIPTION
While protected properties are used through-out the library, the factory class for some unknown (good) reason to me uses privates, making it hard to extend. Had to almost re-write everything for [using with CakePHP](https://github.com/gourmet/knp-menu/blob/master/src/MenuFactory.php).