### PR TITLE
Adds 'parameters' key to testedRoute array

### DIFF
--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -41,7 +41,7 @@ class RouteVoter implements VoterInterface
 
         foreach ($routes as $testedRoute) {
             if (is_string($testedRoute)) {
-                $testedRoute = array('route' => $testedRoute);
+                $testedRoute = array('route' => $testedRoute, 'parameters' => $parameters);
             }
 
             if (!is_array($testedRoute)) {


### PR DESCRIPTION
The 'routesParameters' value was never passed to the isMatchingRoute function so the routesParameters are always ignored.