### PR TITLE
fix bug on boolean in routes

### DIFF
--- a/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
+++ b/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
@@ -22,6 +22,11 @@ class RoutingExtension implements ExtensionInterface
     {
         if (!empty($options['route'])) {
             $params = isset($options['routeParameters']) ? $options['routeParameters'] : array();
+            array_walk($params, function(&$value, $key) {
+                if (is_bool($value)) {
+                    $value = ($value === true) ? 'true': 'false';
+                }
+            });
             $absolute = isset($options['routeAbsolute']) ? $options['routeAbsolute'] : false;
             $options['uri'] = $this->generator->generate($options['route'], $params, $absolute);
 


### PR DESCRIPTION
There was a bug on boolean on routes in symfony intégration, in fact i just convert boolean to string to pass it to the url generate.

If it is not casted we have an exception