### PR TITLE
Integrated more functions into Twig

### DIFF
--- a/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
+++ b/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
@@ -13,6 +13,7 @@ use Knp\Menu\Provider\PimpleProvider as PimpleMenuProvider;
 use Knp\Menu\Renderer\PimpleProvider as PimpleRendererProvider;
 use Knp\Menu\Twig\Helper;
 use Knp\Menu\Twig\MenuExtension;
+use Knp\Menu\Util\MenuManipulator;
 
 class KnpMenuServiceProvider implements ServiceProviderInterface
 {
@@ -60,17 +61,21 @@ class KnpMenuServiceProvider implements ServiceProviderInterface
             return new PimpleRendererProvider($app, $app['knp_menu.default_renderer'], $app['knp_menu.renderers']);
         });
 
+        $app['knp_menu.menu_manipulator'] = $app->share(function () use ($app) {
+            return new MenuManipulator();
+        });
+
         if (!isset($app['knp_menu.default_renderer'])) {
             $app['knp_menu.default_renderer'] = 'list';
         }
 
         $app['knp_menu.helper'] = $app->share(function () use ($app) {
-            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider']);
+            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator']);
         });
 
         if (isset($app['twig'])) {
             $app['knp_menu.twig_extension'] = $app->share(function () use ($app) {
-                return new MenuExtension($app['knp_menu.helper']);
+                return new MenuExtension($app['knp_menu.helper'], $app['knp_menu.matcher'], $app['knp_menu.menu_manipulator']);
             });
 
             $app['knp_menu.renderer.twig'] = $app->share(function () use ($app) {

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -3,27 +3,49 @@
 namespace Knp\Menu\Twig;
 
 use Knp\Menu\ItemInterface;
+use Knp\Menu\Util\MenuManipulator;
+use Knp\Menu\Matcher\MatcherInterface;
 
 class MenuExtension extends \Twig_Extension
 {
     private $helper;
+    private $matcher;
+    private $menuManipulator;
 
     /**
      * @param Helper $helper
      */
-    public function __construct(Helper $helper)
+    public function __construct(Helper $helper, MatcherInterface $matcher = null, MenuManipulator $menuManipulator = null)
     {
         $this->helper = $helper;
+        $this->matcher = $matcher;
+        $this->menuManipulator = $menuManipulator;
     }
 
     public function getFunctions()
     {
         return array(
-            'knp_menu_get' => new \Twig_Function_Method($this, 'get'),
-            'knp_menu_render' => new \Twig_Function_Method($this, 'render', array('is_safe' => array('html'))),
+             new \Twig_SimpleFunction('knp_menu_get', array($this, 'get')),
+             new \Twig_SimpleFunction('knp_menu_render', array($this, 'render'), array('is_safe' => array('html'))),
+             new \Twig_SimpleFunction('knp_menu_get_breadcrumbs_array', array($this, 'getBreadcrumbsArray')),
         );
     }
 
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('knp_menu_as_string', array($this, 'pathAsString')),
+        );
+    }
+
+    public function getTests()
+    {
+        return array(
+            new \Twig_SimpleTest('knp_menu_current', array($this, 'isCurrent')),
+            new \Twig_SimpleTest('knp_menu_ancestor', array($this, 'isAncestor')),
+        );
+    }
+    
     /**
      * Retrieves an item following a path in the tree.
      *
@@ -50,6 +72,71 @@ class MenuExtension extends \Twig_Extension
     public function render($menu, array $options = array(), $renderer = null)
     {
         return $this->helper->render($menu, $options, $renderer);
+    }
+
+    /**
+     * Returns an array ready to be used for breadcrumbs.
+     *
+     * @param ItemInterface|array|string $item
+     * @param string|array|null          $subItem
+     *
+     * @return array
+     */
+    public function getBreadcrumbsArray($menu, $subItem = null)
+    {
+        return $this->helper->getBreadcrumbsArray($menu, $subItem);
+    }
+
+    /**
+     * A string representation of this menu item
+     *
+     * e.g. Top Level > Second Level > This menu
+     *
+     * @param ItemInterface $item
+     * @param string        $separator
+     *
+     * @return string
+     */
+    public function pathAsString(ItemInterface $menu, $separator = ' > ')
+    {
+        if (null === $this->menuManipulator) {
+            throw new \BadMethodCallException('The menu manipulator must be set to get the breadcrumbs array');
+        }
+
+        return $this->menuManipulator->getPathAsString($menu, $separator);
+    }
+
+    /**
+     * Checks whether an item is current.
+     *
+     * @param ItemInterface $item
+     *
+     * @return boolean
+     */
+    public function isCurrent(ItemInterface $item)
+    {
+        if (null === $this->matcher) {
+            throw new \BadMethodCallException('The matcher must be set to get the breadcrumbs array');
+        }
+
+        return $this->matcher->isCurrent($item);
+    }
+
+    /**
+     * Checks whether an item is the ancestor of a current item.
+     *
+     * @param ItemInterface $item
+     * @param integer       $depth The max depth to look for the item
+     *
+     * @return boolean
+     */
+    public function isAncestor(ItemInterface $item, $depth = null)
+    {
+        if (null === $this->matcher) {
+            throw new \BadMethodCallException('The matcher must be set to get the breadcrumbs array');
+        }
+
+        return $this->matcher->isAncestor($item);
     }
 
     /**

--- a/tests/Knp/Menu/Tests/Twig/HelperTest.php
+++ b/tests/Knp/Menu/Tests/Twig/HelperTest.php
@@ -249,4 +249,19 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $helper = new Helper($this->getMock('Knp\Menu\Renderer\RendererProviderInterface'));
         $helper->render(array());
     }
+
+    public function testBreadcrumbsArray()
+    {
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+
+        $manipulator = $this->getMock('Knp\Menu\Util\MenuManipulator');
+        $manipulator->expects($this->any())
+            ->method('getBreadcrumbsArray')
+            ->with($menu)
+            ->will($this->returnValue(array('A', 'B')));
+
+        $helper = new Helper($this->getMock('Knp\Menu\Renderer\RendererProviderInterface'), null, $manipulator);
+
+        $this->assertEquals(array('A', 'B'), $helper->getBreadcrumbsArray($menu));
+    }
 }

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -64,45 +64,6 @@ class MenuExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<p>foobar</p>', $this->getTemplate('{{ knp_menu_render(menu) }}', $helper)->render(array('menu' => 'default')));
     }
 
-    public function testGetMenu()
-    {
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $helper = $this->getHelperMock(array('get'));
-        $helper->expects($this->once())
-            ->method('get')
-            ->with('default')
-            ->will($this->returnValue($menu))
-        ;
-        $extension = new MenuExtension($helper);
-        $this->assertSame($menu, $extension->get('default'));
-    }
-
-    public function testGetMenuWithOptions()
-    {
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $helper = $this->getHelperMock(array('get'));
-        $helper->expects($this->once())
-            ->method('get')
-            ->with('default', array(), array('foo' => 'bar'))
-            ->will($this->returnValue($menu))
-        ;
-        $extension = new MenuExtension($helper);
-        $this->assertSame($menu, $extension->get('default', array(), array('foo' => 'bar')));
-    }
-
-    public function testGetMenuByPath()
-    {
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $helper = $this->getHelperMock(array('get'));
-        $helper->expects($this->once())
-            ->method('get')
-            ->with('default', array('child'))
-            ->will($this->returnValue($menu))
-        ;
-        $extension = new MenuExtension($helper);
-        $this->assertSame($menu, $extension->get('default', array('child')));
-    }
-
     public function testRetrieveMenuByName()
     {
         $menu = $this->getMock('Knp\Menu\ItemInterface');
@@ -121,6 +82,64 @@ class MenuExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<p>foobar</p>', $this->getTemplate('{{ knp_menu_render(knp_menu_get("default")) }}', $helper)->render(array()));
     }
 
+    public function testGetBreadcrumbsArray()
+    {
+        $helper = $this->getHelperMock(array('getBreadcrumbsArray'));
+        $helper->expects($this->any())
+            ->method('getBreadcrumbsArray')
+            ->with('default')
+            ->will($this->returnValue(array('A', 'B')))
+        ;
+
+        $this->assertEquals('A, B', $this->getTemplate('{{ knp_menu_get_breadcrumbs_array("default")|join(", ") }}', $helper)->render(array()));
+    }
+
+    public function testPathAsString()
+    {
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $helper = $this->getHelperMock(array('get'));
+        $manipulator = $this->getManipulatorMock(array('getPathAsString'));
+        $helper->expects($this->any())
+            ->method('get')
+            ->with('default')
+            ->will($this->returnValue($menu));
+        $manipulator->expects($this->any())
+            ->method('getPathAsString')
+            ->with($menu)
+            ->will($this->returnValue('A > B'))
+        ;
+
+        $this->assertEquals('A &gt; B', $this->getTemplate('{{ knp_menu_get("default")|knp_menu_as_string }}', $helper, null, $manipulator)->render(array()));
+    }
+
+    public function testIsCurrent()
+    {
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $helper = $this->getHelperMock(array());
+        $matcher = $this->getMatcherMock();
+        $matcher->expects($this->any())
+            ->method('isCurrent')
+            ->with($menu)
+            ->will($this->returnValue(true))
+        ;
+
+        $this->assertEquals('current', $this->getTemplate('{{ menu is knp_menu_current ? "current" : "not current" }}', $helper, $matcher)->render(array('menu' => $menu)));
+    }
+
+    public function testIsAncestor()
+    {
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $helper = $this->getHelperMock(array());
+        $matcher = $this->getMatcherMock();
+        $matcher->expects($this->any())
+            ->method('isAncestor')
+            ->with($menu)
+            ->will($this->returnValue(false))
+        ;
+
+        $this->assertEquals('not ancestor', $this->getTemplate('{{ menu is knp_menu_ancestor ? "ancestor" : "not ancestor" }}', $helper, $matcher)->render(array('menu' => $menu)));
+    }
+
     private function getHelperMock(array $methods)
     {
         return $this->getMockBuilder('Knp\Menu\Twig\Helper')
@@ -130,17 +149,31 @@ class MenuExtensionTest extends \PHPUnit_Framework_TestCase
         ;
     }
 
+    private function getManipulatorMock(array $methods)
+    {
+        return $this->getMockBuilder('Knp\Menu\Util\MenuManipulator')
+            ->disableOriginalConstructor()
+            ->setMethods($methods)
+            ->getMock()
+        ;
+    }
+
+    private function getMatcherMock()
+    {
+        return $this->getMock('Knp\Menu\Matcher\MatcherInterface');
+    }
+
     /**
      * @param string                $template
      * @param \Knp\Menu\Twig\Helper $helper
      *
      * @return \Twig_Template
      */
-    private function getTemplate($template, $helper)
+    private function getTemplate($template, $helper, $matcher = null, $menuManipulator = null)
     {
         $loader = new \Twig_Loader_Array(array('index' => $template));
         $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
-        $twig->addExtension(new MenuExtension($helper));
+        $twig->addExtension(new MenuExtension($helper, $matcher, $menuManipulator));
 
         return $twig->loadTemplate('index');
     }


### PR DESCRIPTION
Now some functions are moved from `ItemInterface` to utils and other classes, there is no way they can be used inside a template.

This PR adds back some functionality.

As we need this to finish our KnpMenu 2.0 update for the Symfony CMF project, can this please be reviewed and merged quickly and be included in a new minor version?