### PR TITLE
Fix dev-master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.1-dev"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
As dev-master contains new features (at least the new twig integration), it will become 2.1 instead of a new 2.0.x version.

Btw, @stof is there any release plan for 2.1?