### PR TITLE
Add setRoute / getRoute methods

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Menu;
 
+use Symfony\Component\Routing\RouterInterface;
+
 /**
  * Interface implemented by a menu item.
  *

--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -55,6 +55,12 @@ interface ItemInterface extends  \ArrayAccess, \Countable, \IteratorAggregate
      * @return ItemInterface
      */
     public function setUri($uri);
+    
+    public function setRoute($name, array $parameters = array(), $referenceType = RouterInterface::ABSOLUTE_URL);
+
+    public function getRoute();
+
+    public function getRouteParameters();
 
     /**
      * Returns the label that will be used to render this menu item

--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Menu;
 
+use Symfony\Component\Routing\RouterInterface;
+
 /**
  * Default implementation of the ItemInterface
  */
@@ -37,6 +39,17 @@ class MenuItem implements ItemInterface
      * @var string
      */
     protected $uri = null;
+
+    /**
+     * @var string
+     */
+    protected $route = null;
+
+    /**
+     * @var array
+     */
+    protected $routeParameters = array();
+
     /**
      * Attributes for the item
      * @var array
@@ -148,6 +161,33 @@ class MenuItem implements ItemInterface
         $this->uri = $uri;
 
         return $this;
+    }
+
+    public function setRoute($name, array $parameters = array(), $referenceType = RouterInterface::ABSOLUTE_URL)
+    {
+        $this->route = $name;
+        $this->routeParameters = $parameters;
+
+        // create temporary item to get generated URI
+        $child = $this->factory->createItem('', array(
+            'route' => $name,
+            'routeParameters' => $parameters,
+            'routeAbsolute' => $referenceType,
+        ));
+
+        $this->setUri($child->getUri());
+
+        unset($child);
+    }
+
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    public function getRouteParameters()
+    {
+        return $this->routeParameters;
     }
 
     public function getLabel()


### PR DESCRIPTION
For convenience usage `KnpMenu` with Symfony Framework I propose to add `setRoute` / `getRoute` methods.

Example of usage is:
``` php
$menu = $this->factory->createItem('root');
$menu->addChild('First post')->setRoute('post_show', [
    'id' => 1,
], RouterInterface::ABSOLUTE_URL);
```

This PR open for https://github.com/KnpLabs/KnpMenu/issues/200 issue.

It's look like a bit heavy,  but I think it's worth it. The old solution with array is also work if any prefer it.

What do you think, guys?