### PR TITLE
Adding support for `weight` item option.

### DIFF
--- a/src/Knp/Menu/Renderer/SortingRenderer.php
+++ b/src/Knp/Menu/Renderer/SortingRenderer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Knp\Menu\Renderer;
+
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Util\MenuManipulator;
+
+/**
+ * Decorator renderer that adds sort behavior before tree rendering
+ */
+class SortingRenderer implements RendererInterface
+{
+    /**
+     * @var RendererInterface
+     */
+    private $renderer;
+
+    /**
+     * @var MenuManipulator
+     */
+    private $manipulator;
+
+    /**
+     * @var RendererInterface $renderer    The decorated renderer
+     * @var MenuManipulator   $manipulator
+     */
+    public function __construct(RendererInterface $renderer, MenuManipulator $manipulator)
+    {
+        $this->renderer    = $renderer;
+        $this->manipulator = $manipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(ItemInterface $item, array $options = array())
+    {
+        $this->manipulator->sort($item);
+
+        return $this->renderer->render($item, $options);
+    }
+}

--- a/src/Knp/Menu/Util/MenuManipulator.php
+++ b/src/Knp/Menu/Util/MenuManipulator.php
@@ -284,6 +284,37 @@ class MenuManipulator
         return $breadcrumbs;
     }
 
+    public function sort(ItemInterface $item)
+    {
+        $item->setChildren($this->sortChildren($item->getChildren()));
+    }
+
+    private function sortChildren(array $children)
+    {
+        if (empty($children)) {
+            return array();
+        }
+
+        $key  = 0;
+        $sort = array($this, 'sort');
+
+        $children = array_map(function (ItemInterface $item, $label) use(&$key, $sort) {
+            call_user_func($sort, $item);
+
+            return array($item->getExtra('weight', 0), $key++, $item, $label);
+        }, $children, array_keys($children));
+
+        array_multisort($children);
+
+        $sorted = array();
+
+        foreach ($children AS $child) {
+            $sorted[$child[3]] = $child[2];
+        }
+
+        return $sorted;
+    }
+
     private function buildBreadcrumbsArray(ItemInterface $item)
     {
         $breadcrumb = array();

--- a/tests/Knp/Menu/Tests/Renderer/SortingRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/SortingRendererTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Knp\Menu\Tests\Renderer;
+
+use Knp\Menu\MenuFactory;
+use Knp\Menu\Renderer\SortingRenderer;
+use Knp\Menu\Renderer\ListRenderer;
+use Knp\Menu\Matcher\MatcherInterface;
+use Knp\Menu\Util\MenuManipulator;
+
+class SortingRendererTest extends AbstractRendererTest
+{
+    protected function createRenderer(MatcherInterface $matcher)
+    {
+        return new SortingRenderer(
+            new ListRenderer($matcher, array('compressed' => true)),
+            new MenuManipulator()
+        );
+    }
+
+    public function testPrettyRendering()
+    {
+        $factory = new MenuFactory();
+        $menu    = $factory->createItem('Root li', array('childrenAttributes' => array('class' => 'root')));
+        $menu->addChild('Parent 1', array('extras' => array('weight' => 10)));
+        $menu->addChild('Parent 2');
+
+        $rendered = <<<HTML
+<ul class="root">
+  <li class="first">
+    <span>Parent 2</span>
+  </li>
+  <li class="last">
+    <span>Parent 1</span>
+  </li>
+</ul>
+
+HTML;
+
+        $this->assertEquals($rendered, $this->renderer->render($menu, array('compressed' => false, 'depth' => 1)));
+    }
+}

--- a/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
+++ b/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
@@ -22,6 +22,23 @@ class MenuManipulatorTest extends TestCase
         $this->assertEquals(array('c3', 'c1', 'c2', 'c4'), array_keys($menu->getChildren()));
     }
 
+    public function testSortRecursivlyTree()
+    {
+        $menu = new MenuItem('root', new MenuFactory());
+        $menu->addChild('c2');
+        $menu->addChild('c4', array('extras' => array('weight' => 20)));
+        $menu->addChild('c3', array('extras' => array('weight' => 20)));
+        $c1 = $menu->addChild('c1', array('extras' => array('weight' => 10)));
+
+        $c1->addChild('c11');
+        $c1->addChild('c12', array('extras' => array('weight' => -5)));
+
+        $manipulator = new MenuManipulator();
+        $manipulator->sort($menu);
+        $this->assertEquals(array('c2', 'c1', 'c4', 'c3'), array_keys($menu->getChildren()));
+        $this->assertEquals(array('c12', 'c11'), array_keys($menu->getChild('c1')->getChildren()));
+    }
+
     public function testMoveToLastPosition()
     {
         $menu = new MenuItem('root', new MenuFactory());


### PR DESCRIPTION
See #97.

Usage:

``` php
<?php

$factory = new MenuFactory();

$menu = $factory->createItem('My menu');
$menu->addChild('Home', array('uri' => '/', array('extras' => array('weight' => 10))));
$menu->addChild('Comments', array('uri' => '#comments'));
$menu->addChild('Symfony2', array('uri' => 'http://symfony-reloaded.org/'));
$menu->addChild('Coming soon', array('extras' => array('weight' => 10))));

$renderer = new SortingRenderer(new ListRenderer(new \Knp\Menu\Matcher\Matcher()), new MenuManipulator());
echo $renderer->render($menu);
```
