### PR TITLE
update return type in docblock

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -352,7 +352,7 @@ interface ItemInterface extends  \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Return the children as an array of ItemInterface objects
      *
-     * @return array
+     * @return ItemInterface[]
      */
     public function getChildren();
 


### PR DESCRIPTION
Be more precise about the type being returned to improve auto-completion
support for IDE users.