### PR TITLE
Add the support of RequestStack in the route voter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
 env:
     global:
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - SYMFONY_PHPUNIT_REMOVE="symfony/yaml" # keep Prophecy
 
 matrix:
     include:

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev":  {
         "pimple/pimple": "~1.0",
+        "symfony/http-foundation": "~2.4|~3.0",
         "symfony/phpunit-bridge": "~3.3",
         "symfony/routing": "~2.3|~3.0",
         "silex/silex":     "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev":  {
         "pimple/pimple": "~1.0",
         "symfony/http-foundation": "~2.4|~3.0",
+        "symfony/http-kernel": "~2.4|~3.0",
         "symfony/phpunit-bridge": "~3.3",
         "symfony/routing": "~2.3|~3.0",
         "silex/silex":     "~1.0",

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -56,7 +56,7 @@ class RouteVoter implements VoterInterface
     public function matchItem(ItemInterface $item)
     {
         if (null !== $this->requestStack) {
-            $request = $this->requestStack->getCurrentRequest();
+            $request = $this->requestStack->getMasterRequest();
         } else {
             $request = $this->request;
         }

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -4,6 +4,7 @@ namespace Knp\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Voter based on the route
@@ -11,27 +12,60 @@ use Symfony\Component\HttpFoundation\Request;
 class RouteVoter implements VoterInterface
 {
     /**
-     * @var Request
+     * @var RequestStack|null
+     */
+    private $requestStack;
+
+    /**
+     * @var Request|null
      */
     private $request;
 
-    public function __construct(Request $request = null)
+    public function __construct($requestStack = null)
     {
-        $this->request = $request;
+        if ($requestStack instanceof RequestStack) {
+            $this->requestStack = $requestStack;
+        } elseif ($requestStack instanceof Request) {
+            @trigger_error(sprintf('Passing a Request as the first argument for "%s" constructor is deprecated since version 2.3 and wwon\'t be possible in 3.0. Pass a RequestStack instead.', __CLASS__), E_USER_DEPRECATED);
+
+            // BC layer for the old API of the class
+            $this->request = $requestStack;
+        } elseif (null !== $requestStack) {
+            throw new \InvalidArgumentException('The first argument of %s must be null, a RequestStack or a Request. %s given', __CLASS__, is_object($requestStack) ? get_class($requestStack) :  gettype($requestStack));
+        } else {
+            @trigger_error(sprintf('Not passing a RequestStack as the first argument for "%s" constructor is deprecated since version 2.3 and won\'t be possible in 3.0.', __CLASS__), E_USER_DEPRECATED);
+        }
     }
 
+    /**
+     * Sets the request against which the menu should be matched.
+     *
+     * This Request is ignored in case a RequestStack is passed in the constructor.
+     *
+     * @deprecated since version 2.3. Pass a RequestStack to the constructor instead.
+     *
+     * @param Request $request
+     */
     public function setRequest(Request $request)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.3 and will be removed in 3.0. Pass a RequestStack in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+
         $this->request = $request;
     }
 
     public function matchItem(ItemInterface $item)
     {
-        if (null === $this->request) {
+        if (null !== $this->requestStack) {
+            $request = $this->requestStack->getCurrentRequest();
+        } else {
+            $request = $this->request;
+        }
+
+        if (null === $request) {
             return null;
         }
 
-        $route = $this->request->attributes->get('_route');
+        $route = $request->attributes->get('_route');
         if (null === $route) {
             return null;
         }
@@ -47,7 +81,7 @@ class RouteVoter implements VoterInterface
                 throw new \InvalidArgumentException('Routes extra items must be strings or arrays.');
             }
 
-            if ($this->isMatchingRoute($testedRoute)) {
+            if ($this->isMatchingRoute($request, $testedRoute)) {
                 return true;
             }
         }
@@ -55,9 +89,9 @@ class RouteVoter implements VoterInterface
         return null;
     }
 
-    private function isMatchingRoute(array $testedRoute)
+    private function isMatchingRoute(Request $request, array $testedRoute)
     {
-        $route = $this->request->attributes->get('_route');
+        $route = $request->attributes->get('_route');
 
         if (isset($testedRoute['route'])) {
             if ($route !== $testedRoute['route']) {
@@ -75,7 +109,7 @@ class RouteVoter implements VoterInterface
             return true;
         }
 
-        $routeParameters = $this->request->attributes->get('_route_params', array());
+        $routeParameters = $request->attributes->get('_route_params', array());
 
         foreach ($testedRoute['parameters'] as $name => $value) {
             if (!isset($routeParameters[$name]) || $routeParameters[$name] !== (string) $value) {

--- a/tests/Knp/Menu/Tests/Integration/Silex/KnpMenuServiceProviderTest.php
+++ b/tests/Knp/Menu/Tests/Integration/Silex/KnpMenuServiceProviderTest.php
@@ -93,8 +93,13 @@ class KnpMenuServiceProviderTest extends TestCase
         };
 
         $app['test.voter'] = $app->share(function (Application $app) {
-            $voter = new RouteVoter();
-            $voter->setRequest($app['request']);
+            $requestStack = isset($app['request_stack']) ? $app['request_stack'] : null;
+
+            $voter = new RouteVoter($requestStack);
+
+            if (null === $requestStack) {
+                $voter->setRequest($app['request']);
+            }
 
             return $voter;
         });


### PR DESCRIPTION
This adds support of the RequestStack in the RouteVoter. The goal is to get rid of the custom event listener injecting the request in voters in the bundle and to stop accessing the Request as a service in Silex (not done by default though as we don't register the RouteVoter by default currently).

~~This has a potential to break BC: it means we are always matching against the current request. The bundle current uses the master request when voting.
It also means that you cannot force matching against a custom Request instance rather than the stacked ones (no idea why someone would want this though).~~

~~I want to get some feedback about the BC break potential before merging this, which is why it is still marked as WIP.~~ Matching is now done on the master request.
