### PR TITLE
Make sure to check the query parameters

### DIFF
--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -78,7 +78,10 @@ class RouteVoter implements VoterInterface
         $routeParameters = $this->request->attributes->get('_route_params', array());
 
         foreach ($testedRoute['parameters'] as $name => $value) {
-            if (!isset($routeParameters[$name]) || $routeParameters[$name] !== (string) $value) {
+            if (
+                (!isset($routeParameters[$name]) || $routeParameters[$name] !== (string) $value) &&
+                $this->request->query->get($name, false) !== $value
+            ) {
                 return false;
             }
         }

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -53,6 +53,57 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string  $route
+     * @param array $routeParameters
+     * @param string|array$itemRoutes
+     * @param array $queryParameters
+     * @param boolean $expected
+     *
+     * @dataProvider provideQueryData
+     */
+    public function testQueryParameters($route, array $routeParameters, $itemRoutes, array $queryParameters, $expected)
+    {
+        $item = $this->getMock('Knp\Menu\ItemInterface');
+        $item->expects($this->any())
+            ->method('getExtra')
+            ->with($this->equalTo('routes'))
+            ->willReturn($itemRoutes)
+        ;
+
+        $request = new Request();
+        $request->attributes->set('_route', $route);
+        $request->attributes->set('_route_params', $routeParameters);
+
+        foreach ($queryParameters as $name => $value) {
+            $request->query->set($name, $value);
+        }
+
+        $voter = new RouteVoter($request);
+
+        $this->assertSame($expected, $voter->matchItem($item));
+    }
+
+    public function provideQueryData()
+    {
+        return array(
+            'no query param' => array(
+                'foo',
+                array('baz'=>'bar'),
+                array(array('route' => 'foo', 'parameters' => array('baz'=>'bar', 'abc'=>'123'))),
+                array(),
+                false
+            ),
+            'single query param' => array(
+                'foo',
+                array('baz'=>'bar'),
+                array(array('route' => 'foo', 'parameters' => array('baz'=>'bar', 'abc'=>'123'))),
+                array('abc'=>'123'),
+                true
+            )
+        );
+    }
+
+    /**
      * @param string       $route
      * @param array        $parameters
      * @param string|array $itemRoutes

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -91,7 +91,7 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                 array('baz'=>'bar'),
                 array(array('route' => 'foo', 'parameters' => array('baz'=>'bar', 'abc'=>'123'))),
                 array(),
-                false
+                null
             ),
             'single query param' => array(
                 'foo',


### PR DESCRIPTION
This PR make sure we check for query parameters in the route matcher. I found this need when I added a menu to filter search results. The menu looked like this: 
- All (/path/items)
- Some (/path/items?filter=some)
- Few (/path/items?filter=few)
