### PR TITLE
Add new 'knp_menu_get_current_item' Twig function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2 (2016-06-24)
+## 2.2 (unreleased)
 
 * Added a new function to twig: `knp_menu_get_current_item`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2 (2016-06-24)
+
+* Added a new function to twig: `knp_menu_get_current_item`
+
 ## 2.1.1 (2016-01-08)
 
 * Made compatible with Symfony 3

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1-dev"
+            "dev-master": "2.2-dev"
         }
     }
 }

--- a/doc/02-Twig-Integration.markdown
+++ b/doc/02-Twig-Integration.markdown
@@ -183,6 +183,8 @@ menu object in the other functions:
 {% set item = knp_menu_get('sidebar', ['First section']) %}
 
 {% set breadcrumbs_array = knp_menu_get_breadcrumbs_array('main') %}
+
+{% set current_item = knp_menu_get_current_item('main') %}
 ```
 
 In some cases, you may want to build the menu differently according to the
@@ -284,6 +286,7 @@ Twig integration reference
 * `knp_menu_get('menuName' [, ['Path', 'To', 'Item'], ['options']])`: retrieve an item of the menu
 * `knp_menu_render('menuName' [, ['options'], 'rendererName'])`: render a menu
 * `knp_menu_get_breadcrumbs_array('menuName' [, 'subItem'])`: get an array that represent the breadcrumbs of the current page (according to the menu)
+* `knp_menu_get_current_item('menuName')`: retrieve the current item (according to the menu)
 
 ### Filters
 

--- a/doc/02-Twig-Integration.markdown
+++ b/doc/02-Twig-Integration.markdown
@@ -288,6 +288,21 @@ Twig integration reference
 * `knp_menu_get_breadcrumbs_array('menuName' [, 'subItem'])`: get an array that represent the breadcrumbs of the current page (according to the menu)
 * `knp_menu_get_current_item('menuName')`: retrieve the current item (according to the menu)
 
+You can easily generate a breadcrumb of the current page by combining the
+`knp_menu_get_breadcrumbs_array` and `knp_menu_get_current_item` functions:
+
+```jinja
+<ol class="breadcrumb">
+{% for breadcrumb_item in knp_menu_get_breadcrumbs_array(knp_menu_get_current_item('main')) %}
+    {% if not loop.last %}
+    <li><a href="{{ breadcrumb_item.uri }}">{{ breadcrumb_item.label }}</a></li>
+    {% else %}
+    <li class="active">{{ breadcrumb_item.label }}</li>
+    {% endif %}
+{% endfor %}
+</ol>
+```
+
 ### Filters
 
 * `knp_menu_as_string(menuNode [, $separator])`: generate a string representation of the menu item

--- a/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
+++ b/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
@@ -70,7 +70,7 @@ class KnpMenuServiceProvider implements ServiceProviderInterface
         }
 
         $app['knp_menu.helper'] = $app->share(function () use ($app) {
-            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator']);
+            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator'], $app['knp_menu.matcher']);
         });
 
         if (isset($app['twig'])) {

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -173,8 +173,6 @@ class Helper
      */
     private function retrieveCurrentItem(ItemInterface $item)
     {
-        $currentItem = null;
-
         if ($this->matcher->isCurrent($item)) {
             return $item;
         }
@@ -184,11 +182,11 @@ class Helper
                 $currentItem = $this->retrieveCurrentItem($child);
 
                 if (null !== $currentItem) {
-                    break;
+                    return $currentItem;
                 }
             }
         }
 
-        return $currentItem;
+        return null;
     }
 }

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -28,6 +28,7 @@ class MenuExtension extends \Twig_Extension
              new \Twig_SimpleFunction('knp_menu_get', array($this, 'get')),
              new \Twig_SimpleFunction('knp_menu_render', array($this, 'render'), array('is_safe' => array('html'))),
              new \Twig_SimpleFunction('knp_menu_get_breadcrumbs_array', array($this, 'getBreadcrumbsArray')),
+             new \Twig_SimpleFunction('knp_menu_get_current_item', array($this, 'getCurrentItem')),
         );
     }
 
@@ -88,6 +89,30 @@ class MenuExtension extends \Twig_Extension
     }
 
     /**
+     * Returns the current item of a menu.
+     *
+     * @param ItemInterface|string $menu
+     *
+     * @return ItemInterface
+     */
+    public function getCurrentItem($menu)
+    {
+        if (null === $this->matcher) {
+            throw new \BadMethodCallException('The matcher must be set to get the current item of a menu');
+        }
+
+        $rootItem = $this->get($menu);
+
+        $currentItem = $this->retrieveCurrentItem($rootItem);
+
+        if (null === $currentItem) {
+            $currentItem = $rootItem;
+        }
+
+        return $currentItem;
+    }
+
+    /**
      * A string representation of this menu item
      *
      * e.g. Top Level > Second Level > This menu
@@ -145,5 +170,31 @@ class MenuExtension extends \Twig_Extension
     public function getName()
     {
         return 'knp_menu';
+    }
+
+    /**
+     * @param ItemInterface $item
+     *
+     * @return ItemInterface|null
+     */
+    private function retrieveCurrentItem(ItemInterface $item)
+    {
+        $currentItem = null;
+
+        if ($this->isCurrent($item)) {
+            return $item;
+        }
+
+        if ($this->isAncestor($item)) {
+            foreach ($item->getChildren() as $child) {
+                $currentItem = $this->retrieveCurrentItem($child);
+
+                if (null !== $currentItem) {
+                    break;
+                }
+            }
+        }
+
+        return $currentItem;
     }
 }

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -97,13 +97,9 @@ class MenuExtension extends \Twig_Extension
      */
     public function getCurrentItem($menu)
     {
-        if (null === $this->matcher) {
-            throw new \BadMethodCallException('The matcher must be set to get the current item of a menu');
-        }
-
         $rootItem = $this->get($menu);
 
-        $currentItem = $this->retrieveCurrentItem($rootItem);
+        $currentItem = $this->helper->getCurrentItem($rootItem);
 
         if (null === $currentItem) {
             $currentItem = $rootItem;
@@ -170,31 +166,5 @@ class MenuExtension extends \Twig_Extension
     public function getName()
     {
         return 'knp_menu';
-    }
-
-    /**
-     * @param ItemInterface $item
-     *
-     * @return ItemInterface|null
-     */
-    private function retrieveCurrentItem(ItemInterface $item)
-    {
-        $currentItem = null;
-
-        if ($this->isCurrent($item)) {
-            return $item;
-        }
-
-        if ($this->isAncestor($item)) {
-            foreach ($item->getChildren() as $child) {
-                $currentItem = $this->retrieveCurrentItem($child);
-
-                if (null !== $currentItem) {
-                    break;
-                }
-            }
-        }
-
-        return $currentItem;
     }
 }

--- a/tests/Knp/Menu/Tests/Twig/HelperTest.php
+++ b/tests/Knp/Menu/Tests/Twig/HelperTest.php
@@ -2,6 +2,9 @@
 
 namespace Knp\Menu\Tests\Twig;
 
+use Knp\Menu\Matcher\Matcher;
+use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
 use Knp\Menu\Twig\Helper;
 
 class HelperTest extends \PHPUnit_Framework_TestCase
@@ -263,5 +266,33 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $helper = new Helper($this->getMock('Knp\Menu\Renderer\RendererProviderInterface'), null, $manipulator);
 
         $this->assertEquals(array('A', 'B'), $helper->getBreadcrumbsArray($menu));
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testCurrentItemWithoutMatcher()
+    {
+        $helper = new Helper($this->getMock('Knp\Menu\Renderer\RendererProviderInterface'));
+        $helper->getCurrentItem('default');
+    }
+
+    public function testCurrentItem()
+    {
+        $matcher = new Matcher();
+
+        $menu = new MenuItem('root', new MenuFactory());
+        $menu->addChild('c1');
+        $menu['c1']->addChild('c1_1');
+        $menu->addChild('c2');
+        $menu['c2']->addChild('c2_1');
+        $menu['c2']->addChild('c2_2');
+        $menu['c2']['c2_2']->addChild('c2_2_1');
+        $menu['c2']['c2_2']->addChild('c2_2_2')->setCurrent(true);
+        $menu['c2']['c2_2']->addChild('c2_2_3');
+
+        $helper = new Helper($this->getMock('Knp\Menu\Renderer\RendererProviderInterface'), null, null, $matcher);
+
+        $this->assertSame('c2_2_2', $helper->getCurrentItem($menu)->getName());
     }
 }

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -140,6 +140,25 @@ class MenuExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('not ancestor', $this->getTemplate('{{ menu is knp_menu_ancestor ? "ancestor" : "not ancestor" }}', $helper, $matcher)->render(array('menu' => $menu)));
     }
 
+    public function testGetCurrentItem()
+    {
+        $menu = $this->getMock('Knp\Menu\ItemInterface');
+        $helper = $this->getHelperMock(array('get'));
+        $helper->expects($this->once())
+            ->method('get')
+            ->with('default')
+            ->will($this->returnValue($menu))
+        ;
+        $matcher = $this->getMatcherMock();
+        $matcher->expects($this->any())
+            ->method('isCurrent')
+            ->with($menu)
+            ->will($this->returnValue(true))
+        ;
+
+        $this->assertEquals('current', $this->getTemplate('{{ knp_menu_get_current_item("default") is knp_menu_current ? "current" : "not current" }}', $helper, $matcher)->render(array()));
+    }
+
     private function getHelperMock(array $methods)
     {
         return $this->getMockBuilder('Knp\Menu\Twig\Helper')

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -143,7 +143,7 @@ class MenuExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetCurrentItem()
     {
         $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $helper = $this->getHelperMock(array('get'));
+        $helper = $this->getHelperMock(array('get', 'getCurrentItem'));
         $helper->expects($this->once())
             ->method('get')
             ->with('default')


### PR DESCRIPTION
The source Gist: https://gist.github.com/fsevestre/b378606c4fd23814278a

This PR add a new `knp_menu_get_current_item(menu)` Twig function which returns the current item of the menu provided as argument.

For example, this new Twig function can be used with the `knp_menu_get_breadcrumbs_array` Twig function to easily display the breadcrumb of the current page:

```TWIG
<ol class="breadcrumb">
{% for breadcrumb_item in knp_menu_get_breadcrumbs_array(knp_menu_get_current_item('main')) %}
    {% if not loop.last %}
    <li><a href="{{ breadcrumb_item.uri }}">{{ breadcrumb_item.label }}</a></li>
    {% else %}
    <li class="active">{{ breadcrumb_item.label }}</li>
    {% endif %}
{% endfor %}
</ol>
```