### PR TITLE
Stop mocking unused method call

### DIFF
--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -33,15 +33,8 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
         $item = $this->getMock('Knp\Menu\ItemInterface');
         $item->expects($this->any())
             ->method('getExtra')
-            ->with($this->logicalOr($this->equalTo('routes'), $this->equalTo('routesParameters')))
-            ->will($this->returnCallback(function ($parameter) {
-                switch ($parameter) {
-                    case 'routes':
-                        return array(array('invalid' => 'array'));
-                    case 'routesParameters':
-                        return array();
-                }
-            }));
+            ->with('routes')
+            ->will($this->returnValue(array(array('invalid' => 'array'))));
 
         $request = new Request();
         $request->attributes->set('_route', 'foo');
@@ -61,20 +54,13 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider provideData
      */
-    public function testMatching($route, array $parameters, $itemRoutes, array $itemsRoutesParameters, $expected)
+    public function testMatching($route, array $parameters, $itemRoutes, $expected)
     {
         $item = $this->getMock('Knp\Menu\ItemInterface');
         $item->expects($this->any())
             ->method('getExtra')
-            ->with($this->logicalOr($this->equalTo('routes'), $this->equalTo('routesParameters')))
-            ->will($this->returnCallback(function ($parameter) use ($itemRoutes, $itemsRoutesParameters) {
-                switch ($parameter) {
-                    case 'routes':
-                        return $itemRoutes;
-                    case 'routesParameters':
-                        return $itemsRoutesParameters;
-                }
-            }))
+            ->with('routes')
+            ->will($this->returnValue($itemRoutes))
         ;
 
         $request = new Request();
@@ -93,91 +79,78 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                 null,
                 array(),
                 'foo',
-                array(),
                 null
             ),
             'integer parameters' => array(
                 'foo',
                 array('bar' => 128),
                 array(array('route' => 'foo', 'parameters' => array('bar' => 128))),
-                array(),
                 null
             ),
             'no item route' => array(
                 'foo',
                 array(),
                 null,
-                array(),
                 null
             ),
             'same single route' => array(
                 'foo',
                 array(),
                 'foo',
-                array(),
                 true
             ),
             'different single route' => array(
                 'foo',
                 array(),
                 'bar',
-                array(),
                 null
             ),
             'matching multiple routes' => array(
                 'foo',
                 array(),
                 array('foo', 'baz'),
-                array(),
                 true
             ),
             'matching multiple routes 2' => array(
                 'baz',
                 array(),
                 array('foo', 'baz'),
-                array(),
                 true
             ),
             'different multiple routes' => array(
                 'foo',
                 array(),
                 array('bar', 'baz'),
-                array(),
                 null
             ),
             'same single route with different parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('route' => 'foo', 'parameters' => array('1' => 'baz'))),
-                array(),
                 null
             ),
             'same single route with same parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('route' => 'foo', 'parameters' => array('1' => 'bar'))),
-                array(),
                 true
             ),
             'same single route with additional parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('route' => 'foo', 'parameters' => array('1' => 'bar', '2' >+ 'baz'))),
-                array(),
                 null
             ),
             'same single route with less parameters' => array(
                 'foo',
                 array('1' => 'bar', '2' => 'baz'),
                 array(array('route' => 'foo', 'parameters' => array('1' => 'bar'))),
-                array(),
                 true
             ),
             'same single route with different type parameters' => array(
                 'foo',
                 array('1' => '2'),
                 array(array('route' => 'foo', 'parameters' => array('1' => 2))),
-                array(),
                 true
             ),
             'same route with multiple route params' => array(
@@ -187,7 +160,6 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                     array('route' => 'foo', 'parameters' => array('1' => 'baz')),
                     array('route' => 'foo', 'parameters' => array('1' => 'bar')),
                 ),
-                array(),
                 true
             ),
             'same route with and without route params' => array(
@@ -197,7 +169,6 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                     array('route' => 'foo', 'parameters' => array('1' => 'baz')),
                     array('route' => 'foo'),
                 ),
-                array(),
                 true
             ),
             'same route with multiple different route params' => array(
@@ -207,34 +178,29 @@ class RouteVoterTest extends \PHPUnit_Framework_TestCase
                     array('route' => 'foo', 'parameters' => array('1' => 'baz')),
                     array('route' => 'foo', 'parameters' => array('1' => 'foo')),
                 ),
-                array(),
                 null
             ),
             'matching pattern without parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('pattern' => '/fo/')),
-                array(),
                 true
             ),
             'non matching pattern without parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('pattern' => '/bar/')),
-                array(),
                 null
             ),
             'matching pattern with parameters' => array(
                 'foo',
                 array('1' => 'bar'),
                 array(array('pattern' => '/fo/', 'parameters' => array('1' => 'bar'))),
-                array(),
                 true
             ),
             'matching pattern with different parameters' => array(
                 'foo', array('1' => 'bar'),
                 array(array('pattern' => '/fo/', 'parameters' => array('1' => 'baz'))),
-                array(),
                 null
             ),
         );


### PR DESCRIPTION
`getExtra` is no longer called with the 'routesParameter' parameter. This should have been removed in #204