### PR TITLE
exception for trying to set item as parent of itself

### DIFF
--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -417,6 +417,10 @@ class MenuItem implements ItemInterface
 
     public function setParent(ItemInterface $parent = null)
     {
+        if ($parent === $this) {
+            throw new \InvalidArgumentException('Item cannot be a child of itself');
+        }
+
         $this->parent = $parent;
 
         return $this;


### PR DESCRIPTION
For now, if we set current item as parent, we will get recursion and application will crash.
So, I propose to ensure that parent is not a item itself.