### PR TITLE
Silex 2 integration.

### DIFF
--- a/doc/03-Silex-Integration.markdown
+++ b/doc/03-Silex-Integration.markdown
@@ -1,24 +1,11 @@
-Silex 1 Integration
-===================
+Silex Integration
+=================
 
 KnpMenu provides an extension for the [Silex](http://silex-project.org/)
-microframework version 1. **This extension is not compatible with Silex 2.** 
-If you use Silex version 2, please do a pull request to provide the necessary
-integration.
+microframework.
 
-RouterAwareFactory
-------------------
-
-The `Knp\Menu\Silex\RouterAwareFactory` extends the default factory to add
-the support of the url generator of the Symfony2 Routing component. You can
-then pass 3 new options to the factory:
-
-* `route`: The route name (the generator will be used if the name is not `null`)
-* `routeParameters`: The parameters to generate the url (if omitted, an empty array is used)
-* `routeAbsolute`: Whether the generated url should be absolute (default `false`)
-
->**NOTE**
->When you give both a route and an uri to the factory, the route will be used.
+For version 1 use `\Knp\Menu\Integration\Silex\KnpMenuServiceProvider.php`.
+For version 2 use `\Knp\Menu\Integration\Silex2\KnpMenuServiceProvider.php`.
 
 Using the KnpMenuExtension
 --------------------------
@@ -27,9 +14,6 @@ Using the KnpMenuExtension
 
 ```php
 <?php
-
-// registering the autoloader for the library.
-$app['autoloader']->registerNamespace('Knp\Menu', __DIR__.'/vendor/KnpMenu/src');
 
 // registering the extension
 $app->register(new \Knp\Menu\Integration\Silex\KnpMenuServiceProvider());

--- a/src/Knp/Menu/Integration/Silex2/KnpMenuServiceProvider.php
+++ b/src/Knp/Menu/Integration/Silex2/KnpMenuServiceProvider.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Knp\Menu\Integration\Silex2;
+
+use Knp\Menu\Integration\Symfony\RoutingExtension;
+use Knp\Menu\Matcher\Matcher;
+use Knp\Menu\Matcher\Voter\UriVoter;
+use Knp\Menu\Matcher\Voter\RouteVoter;
+use Knp\Menu\MenuFactory;
+use Knp\Menu\Provider\ArrayAccessProvider as PimpleMenuProvider;
+use Knp\Menu\Renderer\ArrayAccessProvider as PimpleRendererProvider;
+use Knp\Menu\Renderer\ListRenderer;
+use Knp\Menu\Renderer\TwigRenderer;
+use Knp\Menu\Twig\Helper;
+use Knp\Menu\Twig\MenuExtension;
+use Knp\Menu\Util\MenuManipulator;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class KnpMenuServiceProvider implements ServiceProviderInterface {
+
+    public function register(Container $app) {
+        $app['knp_menu.factory'] = function($app) {
+            $factory = new MenuFactory();
+
+            if ( isset($app['url_generator']) ) {
+                $factory->addExtension(new RoutingExtension( $app['url_generator'] ));
+            }
+
+            return $factory;
+        };
+
+        $app['knp_menu.matcher'] = function($app) {
+            $matcher = new Matcher();
+
+            if ( is_callable($app['knp_menu.matcher.configure']) ) {
+                $app['knp_menu.matcher.configure']($matcher);
+            }
+
+            return $matcher;
+        };
+
+        if ( !isset($app['knp_menu.matcher.configure']) ) {
+            $app['knp_menu.matcher.configure'] = $app->protect(function($matcher) use ($app) {
+                $matcher->addVoter(new UriVoter($_SERVER['REQUEST_URI']));
+                $matcher->addVoter(new RouteVoter( $app['request_stack']->getCurrentRequest() ));
+            });
+        }
+
+        $app['knp_menu.menu_provider'] = function($app) {
+            return new PimpleMenuProvider($app, $app['knp_menu.menus']);
+        };
+
+        if ( !isset($app['knp_menu.menus']) ) {
+            $app['knp_menu.menus'] = array();
+        }
+
+        $app['knp_menu.renderer.list'] = function($app) {
+            return new ListRenderer($app['knp_menu.matcher'], array(), $app['charset']);
+        };
+
+        $app['knp_menu.renderer_provider'] = function($app) {
+            $app['knp_menu.renderers'] = array_merge(
+                array('list' => 'knp_menu.renderer.list'),
+                isset($app['knp_menu.renderer.twig']) ? array('twig' => 'knp_menu.renderer.twig') : array(),
+                isset($app['knp_menu.renderers']) ? $app['knp_menu.renderers'] : array()
+            );
+
+            return new PimpleRendererProvider($app, $app['knp_menu.default_renderer'], $app['knp_menu.renderers']);
+        };
+
+        if ( !isset($app['knp_menu.default_renderer']) ) {
+            $app['knp_menu.default_renderer'] = 'list';
+        }
+
+        $app['knp_menu.menu_manipulator'] = function($app) {
+            return new MenuManipulator();
+        };
+
+        $app['knp_menu.helper'] = function($app) {
+            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator']);
+        };
+
+        if ( isset($app['twig']) ) {
+            $app['knp_menu.twig_extension'] = function($app) {
+                return new MenuExtension($app['knp_menu.helper'], $app['knp_menu.matcher'], $app['knp_menu.menu_manipulator']);
+            };
+
+            $app['knp_menu.renderer.twig'] = function($app) {
+                return new TwigRenderer($app['twig'], $app['knp_menu.template'], $app['knp_menu.matcher']);
+            };
+
+            if ( !isset($app['knp_menu.template']) ) {
+                $app['knp_menu.template'] = 'knp_menu.html.twig';
+            }
+
+            $app->extend('twig', function($twig) use ($app) {
+                $twig->addExtension($app['knp_menu.twig_extension']);
+                return $twig;
+            });
+
+            $app->extend('twig.loader.filesystem', function(\Twig_Loader_Filesystem $loader) use($app) {
+                $loader->addPath(__DIR__.'/../../Resources/views');
+                return $loader;
+            });
+        };
+    }
+
+}

--- a/src/Knp/Menu/Integration/Silex2/KnpMenuServiceProvider.php
+++ b/src/Knp/Menu/Integration/Silex2/KnpMenuServiceProvider.php
@@ -78,7 +78,7 @@ class KnpMenuServiceProvider implements ServiceProviderInterface {
         };
 
         $app['knp_menu.helper'] = function($app) {
-            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator']);
+            return new Helper($app['knp_menu.renderer_provider'], $app['knp_menu.menu_provider'], $app['knp_menu.menu_manipulator'], $app['knp_menu.matcher']);
         };
 
         if ( isset($app['twig']) ) {


### PR DESCRIPTION
Added an additional `KnpMenuServiceProvider` targeted for integration with Silex 2. Parameters and services follow the Silex 1 integration.

Documentation has been updated accordingly, removing section related to the removed `Knp\Menu\Silex\RouterAwareFactory`.