### PR TITLE
Implement a menu provider building menu thanks to lazy-loaded builder

### DIFF
--- a/src/Knp/Menu/Provider/LazyProvider.php
+++ b/src/Knp/Menu/Provider/LazyProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Knp\Menu\Provider;
+
+/**
+ * A menu provider building menus lazily thanks to builder callables.
+ *
+ * Builders can either be callables or a factory for an object callable
+ * represented as array(Closure, method), where the Closure gets called
+ * to instantiate the object.
+ */
+class LazyProvider implements MenuProviderInterface
+{
+    private $builders;
+
+    public function __construct(array $builders)
+    {
+        $this->builders = $builders;
+    }
+
+    public function get($name, array $options = array())
+    {
+        if (!isset($this->builders[$name])) {
+            throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+        }
+
+        $builder = $this->builders[$name];
+
+        if (is_array($builder) && isset($builder[0]) && $builder[0] instanceof \Closure) {
+            $builder[0] = $builder[0]();
+        }
+
+        if (!is_callable($builder)) {
+            throw new \LogicException(sprintf('Invalid menu builder for "%s". A callable or a factory for an object callable are expected.', $name));
+        }
+
+        return call_user_func($builder, $options);
+    }
+
+    public function has($name, array $options = array())
+    {
+        return isset($this->builders[$name]);
+    }
+}

--- a/tests/Knp/Menu/Tests/Provider/LazyProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/LazyProviderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Knp\Menu\Tests\Provider;
+
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Provider\ArrayAccessProvider;
+use Knp\Menu\Provider\LazyProvider;
+
+class LazyProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHas()
+    {
+        $provider = new LazyProvider(array('first' => function () {}, 'second' => function () {}));
+        $this->assertTrue($provider->has('first'));
+        $this->assertTrue($provider->has('second'));
+        $this->assertFalse($provider->has('third'));
+    }
+
+    public function testGetExistentMenu()
+    {
+        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $provider = new LazyProvider(array('default' => function () use ($menu) {
+            return $menu;
+        }));
+        $this->assertSame($menu, $provider->get('default'));
+    }
+
+    public function testGetMenuAsClosure()
+    {
+        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $provider = new LazyProvider(array('default' => array(function () use ($menu) {
+            return new FakeBuilder($menu);
+        }, 'build')));
+
+        $this->assertSame($menu, $provider->get('default', array('foo' => 'bar')));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetNonExistentMenu()
+    {
+        $provider = new LazyProvider(array());
+        $provider->get('non-existent');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGetWithBrokenBuilder()
+    {
+        $provider = new LazyProvider(array('broken' => new \stdClass()));
+        $provider->get('broken');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGetWithBrokenLazyBuilder()
+    {
+        $provider = new LazyProvider(array('broken' => array(function () {return new \stdClass();}, 'nonExistentMethod')));
+        $provider->get('broken');
+    }
+}
+
+class FakeBuilder
+{
+    private $menu;
+
+    public function __construct(ItemInterface $menu)
+    {
+        $this->menu = $menu;
+    }
+
+    public function build(array $options)
+    {
+        return $this->menu;
+    }
+}


### PR DESCRIPTION
The usage of a Closure to lazily instantiate the object of the callable is inspired by Symfony EventDispatcher 3.3+, allowing to use the lazy-loading features of Symfony DI 3.3+ without injecting the container.
However, this implementation has nothing specific to Symfony DI (except the convention about how it works to be compatible). The class is usable standalone if you provide builders in the same format. This is why I'm adding this class in the library rather than the bundle.