### PR TITLE
Improve the Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
 
 before_install:
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    # force the PHPUnit version for PHP 7.2, until https://github.com/symfony/symfony/issues/23943 is resolved
+    - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then export SYMFONY_PHPUNIT_VERSION="6.3"; fi;
 
 install:
     - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,37 @@ sudo: false
 cache:
     directories:
         - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - nightly
+
+env:
+    global:
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
 
 matrix:
     include:
-        - php: 5.3
-          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 5.6
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+        - php: 7.1
           env: DEPENDENCIES=dev
         - php: hhvm
           dist: trusty
+        - php: 5.3
+          dist: precise
 
 before_install:
-    - composer self-update
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
     - composer update $COMPOSER_FLAGS
+    - ./vendor/bin/simple-phpunit install
 
 script:
     - php ./vendor/bin/simple-phpunit

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 KnpLabs - http://www.knplabs.com
+Copyright (c) 2011-present KnpLabs - https://knplabs.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "type":         "library",
     "description":  "An object oriented menu library",
     "keywords":     ["menu", "tree"],
-    "homepage":     "http://knplabs.com",
+    "homepage":     "https://knplabs.com",
     "license":      "MIT",
     "authors":      [
         {
             "name":     "KnpLabs",
-            "homepage": "http://knplabs.com"
+            "homepage": "https://knplabs.com"
         },
         {
             "name":     "Christophe Coevoet",


### PR DESCRIPTION
- Ensure PHP 5.3 always run on precise, even if Travis migrates us to Trusty for other jobs (Trusty only has PHP 5.4+)
- keep the PHPUnit install in the Travis cache
- add testing on PHP nightly