### PR TITLE
Add validation of the composer.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,5 @@ install:
     - ./vendor/bin/simple-phpunit install
 
 script:
+    - composer validate --strict --no-check-lock
     - php ./vendor/bin/simple-phpunit


### PR DESCRIPTION
This prevents PRs breaking the validity of the composer.json, which would then be rejected by Packagist.
The lock file is not validated, as it is not committed in the repo.