### PR TITLE
Add support for iterables in the ChainProvider

### DIFF
--- a/src/Knp/Menu/Provider/ChainProvider.php
+++ b/src/Knp/Menu/Provider/ChainProvider.php
@@ -4,12 +4,12 @@ namespace Knp\Menu\Provider;
 
 class ChainProvider implements MenuProviderInterface
 {
-    /**
-     * @var MenuProviderInterface[]
-     */
     private $providers;
 
-    public function __construct(array $providers)
+    /**
+     * @param MenuProviderInterface[]|iterable $providers
+     */
+    public function __construct($providers)
     {
         $this->providers = $providers;
     }

--- a/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
@@ -77,4 +77,17 @@ class ChainProviderTest extends TestCase
         $provider = new ChainProvider(array());
         $provider->get('non-existent');
     }
+
+    public function testIterator()
+    {
+        $menu = $this->prophesize('Knp\Menu\ItemInterface');
+
+        $innerProvider = $this->prophesize('Knp\Menu\Provider\MenuProviderInterface');
+        $innerProvider->has('foo', array())->willReturn(true);
+        $innerProvider->get('foo', array())->willReturn($menu);
+
+        $provider = new ChainProvider(new \ArrayIterator(array($innerProvider->reveal())));
+        $this->assertTrue($provider->has('foo'));
+        $this->assertSame($menu->reveal(), $provider->get('foo'));
+    }
 }


### PR DESCRIPTION
Using an iterator rather than an array can allow lazy-loading providers, as the iteration stops as soon as the provider supporting the menu is found.