### PR TITLE
Add support for providing voters as an iterator

### DIFF
--- a/src/Knp/Menu/Matcher/Matcher.php
+++ b/src/Knp/Menu/Matcher/Matcher.php
@@ -11,24 +11,35 @@ use Knp\Menu\Matcher\Voter\VoterInterface;
 class Matcher implements MatcherInterface
 {
     private $cache;
+    private $voters;
 
     /**
-     * @var VoterInterface[]
+     * @param VoterInterface[]|iterable $voters
      */
-    private $voters = array();
-
-    public function __construct()
+    public function __construct($voters = array())
     {
+        $this->voters = $voters;
         $this->cache = new \SplObjectStorage();
     }
 
     /**
      * Adds a voter in the matcher.
      *
+     * If an iterator was used to provide voters in the constructor, it will be
+     * converted to array when using this method, breaking any potential lazy-loading.
+     *
+     * @deprecated since 2.3. Pass voters in the constructor instead.
+     *
      * @param VoterInterface $voter
      */
     public function addVoter(VoterInterface $voter)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.3 and will be removed in 3.0. Pass voters in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+
+        if ($this->voters instanceof \Traversable) {
+            $this->voters = iterator_to_array($this->voters);
+        }
+
         $this->voters[] = $voter;
     }
 

--- a/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
@@ -63,8 +63,7 @@ class MatcherTest extends TestCase
         $voter->expects($this->never())
             ->method('matchItem');
 
-        $matcher = new Matcher();
-        $matcher->addVoter($voter);
+        $matcher = new Matcher(array($voter));
 
         $this->assertSame($value, $matcher->isCurrent($item));
     }
@@ -91,9 +90,95 @@ class MatcherTest extends TestCase
         $voter2->expects($this->never())
             ->method('matchItem');
 
+        $matcher = new Matcher(array($voter1, $voter2));
+
+        $this->assertSame($value, $matcher->isCurrent($item));
+    }
+
+    /**
+     * @param boolean $value
+     *
+     * @dataProvider provideBoolean
+     */
+    public function testVoterIterator($value)
+    {
+        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item->expects($this->any())
+            ->method('isCurrent')
+            ->will($this->returnValue(null));
+
+        $voter1 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter1->expects($this->once())
+            ->method('matchItem')
+            ->with($this->equalTo($item))
+            ->will($this->returnValue($value));
+
+        $voter2 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter2->expects($this->never())
+            ->method('matchItem');
+
+        $matcher = new Matcher(new \ArrayIterator(array($voter1, $voter2)));
+
+        $this->assertSame($value, $matcher->isCurrent($item));
+    }
+
+    /**
+     * @param boolean $value
+     *
+     * @group legacy
+     *
+     * @dataProvider provideBoolean
+     */
+    public function testVoterSetter($value)
+    {
+        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item->expects($this->any())
+            ->method('isCurrent')
+            ->will($this->returnValue(null));
+
+        $voter1 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter1->expects($this->once())
+            ->method('matchItem')
+            ->with($this->equalTo($item))
+            ->will($this->returnValue($value));
+
+        $voter2 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter2->expects($this->never())
+            ->method('matchItem');
+
         $matcher = new Matcher();
         $matcher->addVoter($voter1);
         $matcher->addVoter($voter2);
+
+        $this->assertSame($value, $matcher->isCurrent($item));
+    }
+
+    /**
+     * @param boolean $value
+     *
+     * @group legacy
+     *
+     * @dataProvider provideBoolean
+     */
+    public function testVoterIteratorInConstructorAndExtraVoter($value)
+    {
+        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item->expects($this->any())
+            ->method('isCurrent')
+            ->will($this->returnValue(null));
+
+        $voter1 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter1->expects($this->once())
+            ->method('matchItem')
+            ->with($this->equalTo($item))
+            ->will($this->returnValue($value));
+
+        $voter2 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter2->expects($this->never())
+            ->method('matchItem');
+
+        $matcher = new Matcher(new \ArrayIterator(array($voter1)));
+        $matcher->addVoter($voter2); // Added through the getter to ensure it works when using an iterator.
 
         $this->assertSame($value, $matcher->isCurrent($item));
     }


### PR DESCRIPTION
This can allow lazy-loading them until they are needed.

I'm wondering whether `addVoter` should be deprecated instead of silently breaking lazy-loading, forcing voters to be provided in the constructor.
For people using the bundle, such deprecation would have no impact (unless they register custom voters manually with a compiler pass rather than using the tag, but they would just see a deprecation warning), as voter registration is handled by the bundle (and next version of the bundle will use the constructor, and provide lazy-loading for Symfony 3.3+).
For people using the Silex 1 integration, this would just require me to provide the necessary hook in https://github.com/KnpLabs/KnpMenuServiceProvider, but the hook available in the legacy service provider in KnpMenu is deprecated anyway in the new package, so it is a matter of updating the doc of this package before releasing its new version.

What do you think @dbu @flug ?