### PR TITLE
Drop support for PHP < 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
         - $HOME/symfony-bridge/.phpunit
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -26,19 +24,13 @@ matrix:
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1
           env: DEPENDENCIES=dev
-        - php: hhvm
-          dist: trusty
-        - php: 5.3
-          dist: precise
 
 before_install:
-    # Test the legacy Silex integration on the PHP 5.5 job. It is not tested on all jobs as it prevents testing with Symfony 3
-    - if [ "$TRAVIS_PHP_VERSION" = "5.5" ]; then composer require --no-update --dev silex/silex "^1.0"; fi;
+    # Test the legacy Silex integration on the PHP 7.0 job. It is not tested on all jobs as it prevents testing with Symfony 3
+    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then composer require --no-update --dev silex/silex "^1.0"; fi;
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     # force the PHPUnit version for PHP 7.2, until https://github.com/symfony/symfony/issues/23943 is resolved
     - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then export SYMFONY_PHPUNIT_VERSION="6.3"; fi;
-    # Account for https://github.com/symfony/symfony/pull/24102 until the bugfix is released
-    - mkdir -p "$SYMFONY_PHPUNIT_DIR"
 
 install:
     - composer update $COMPOSER_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require":      {
-        "php":  ">=5.3.0"
+        "php":  ">=5.6.0"
     },
     "require-dev":  {
         "psr/container": "^1.0",


### PR DESCRIPTION
These PHP versions are not maintained anymore.

Closes #273

I also removed HHVM from the Travis setup, as they announced that the would not attempt feature parity with PHP anymore: http://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html