### PR TITLE
Change "Symfony2" references

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@ KnpMenu
 =======
 
 The KnpMenu library provides object oriented menus for PHP 5.3.
-It is used by the [KnpMenuBundle](https://github.com/KnpLabs/KnpMenuBundle) for Symfony2
+It is used by the [KnpMenuBundle](https://github.com/KnpLabs/KnpMenuBundle) for Symfony
 but can now be used stand-alone.
 
 [![Build Status](https://secure.travis-ci.org/KnpLabs/KnpMenu.svg)](http://travis-ci.org/KnpLabs/KnpMenu)
@@ -38,8 +38,8 @@ $factory = new MenuFactory();
 $menu = $factory->createItem('My menu');
 $menu->addChild('Home', array('uri' => '/'));
 $menu->addChild('Comments', array('uri' => '#comments'));
-$menu->addChild('Symfony2', array('uri' => 'http://symfony-reloaded.org/'));
-$menu->addChild('Coming soon');
+$menu->addChild('Symfony', array('uri' => 'http://symfony.com/'));
+$menu->addChild('Happy Awesome Developers');
 
 $renderer = new ListRenderer(new \Knp\Menu\Matcher\Matcher());
 echo $renderer->render($menu);
@@ -56,10 +56,10 @@ The above menu would render the following HTML:
     <a href="#comments">Comments</a>
   </li>
   <li>
-    <a href="http://symfony-reloaded.org/">Symfony2</a>
+    <a href="http://symfony.com/">Symfony</a>
   </li>
   <li class="last">
-    <span>Coming soon</span>
+    <span>Happy Awesome Developers</span>
   </li>
 </ul>
 ```

--- a/doc/01-Basic-Menus.markdown
+++ b/doc/01-Basic-Menus.markdown
@@ -29,7 +29,7 @@ $factory = new MenuFactory();
 $menu = $factory->createItem('My menu');
 $menu->addChild('Home', array('uri' => '/'));
 $menu->addChild('Comments', array('uri' => '#comments'));
-$menu->addChild('Symfony2', array('uri' => 'http://symfony-reloaded.org/'));
+$menu->addChild('Symfony', array('uri' => 'http://symfony.com/'));
 
 $renderer = new ListRenderer(new Matcher());
 echo $renderer->render($menu);
@@ -46,7 +46,7 @@ The above would render the following html code:
     <a href="#comments">Comments</a>
   </li>
   <li class="last">
-    <a href="http://symfony-reloaded.org/">Symfony2</a>
+    <a href="http://symfony.com/">Symfony</a>
   </li>
 </ul>
 ```

--- a/doc/05-Matcher.md
+++ b/doc/05-Matcher.md
@@ -32,7 +32,7 @@ Available voters
 KnpMenu provides some voters for standard cases:
 
 * `RegexVoter`: checks if the request matches a regular expression you pass to the voter
-* `RouteVoter`: uses a Symfony2 request to check if the current route is same as the route of the menu item
+* `RouteVoter`: uses a Symfony request to check if the current route is same as the route of the menu item
 * `UriVoter`: compare the URI of the menu item with the URI passed to the voter
 
 Create your own voters

--- a/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
+++ b/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
@@ -7,7 +7,7 @@ use Knp\Menu\ItemInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
- * Factory able to use the Symfony2 Routing component to build the url
+ * Factory able to use the Symfony Routing component to build the url
  */
 class RoutingExtension implements ExtensionInterface
 {


### PR DESCRIPTION
Please don't hesitate to reject this if there is a good reason that it is still the way/version it was … but "hype train" :wink: 