### PR TITLE
Switch to namespaced Twig classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,15 @@
     "require":      {
         "php":  ">=5.6.0"
     },
+    "conflict": {
+        "twig/twig": "<1.34|>=2,<2.4"
+    },
     "require-dev":  {
         "psr/container": "^1.0",
         "symfony/http-foundation": "~2.4|~3.0|^4.0",
         "symfony/phpunit-bridge": "~3.3|^4.0",
         "symfony/routing": "~2.3|~3.0|^4.0",
-        "twig/twig":       "~1.16|~2.0"
+        "twig/twig":       "~1.34|~2.4"
     },
     "suggest":      {
         "twig/twig":    "for the TwigRenderer and the integration with your templates"

--- a/doc/02-Twig-Integration.markdown
+++ b/doc/02-Twig-Integration.markdown
@@ -19,10 +19,10 @@ to pass both the renderer and menu into a template:
 <?php
 
 // bootstrap Twig
-$twigLoader = new \Twig_Loader_Filesystem(array(
+$twigLoader = new \Twig\Loader\FilesystemLoader(array(
     // path to your templates
 ));
-$twig = new \Twig_Environment($twigLoader); // you can add the charset (i.e. ISO-8859-1) in the array of options if you need 
+$twig = new \Twig\Environment($twigLoader); // you can add the charset (i.e. ISO-8859-1) in the array of options if you need 
 
 $itemMatcher = new \Knp\Menu\Matcher\Matcher();
 // setup some renderer
@@ -30,8 +30,7 @@ $renderer = new \Knp\Menu\Renderer\ListRenderer($itemMatcher);
 //$menuRenderer = new \Knp\Menu\Renderer\TwigRenderer($twig, 'knp_menu.html.twig', $itemMatcher);
 
 // render a template
-$template = $twig->loadTemplate('menu.twig');
-echo $template->display(array(
+$twig->display('menu.twig', array(
     'renderer' => $renderer,
     'menu' => $menu
 ));
@@ -226,12 +225,12 @@ when bootstrapping Twig.
 ```php
 <?php
 
-$twigLoader = new \Twig_Loader_Filesystem(array(
+$twigLoader = new \Twig\Loader\FilesystemLoader(array(
     __DIR__.'/vendor/KnpMenu/src/Knp/Menu/Resources/views',
     // your own paths
 ));
-$twig = new \Twig_Environment($twigLoader);
-$itemMatcher = \Knp\Menu\Matcher\Matcher();
+$twig = new \Twig\Environment($twigLoader);
+$itemMatcher = new \Knp\Menu\Matcher\Matcher();
 $menuRenderer = new \Knp\Menu\Renderer\TwigRenderer($twig, 'knp_menu.html.twig', $itemMatcher);
 ```
 

--- a/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
+++ b/src/Knp/Menu/Integration/Silex/KnpMenuServiceProvider.php
@@ -16,6 +16,8 @@ use Knp\Menu\Renderer\ArrayAccessProvider as PimpleRendererProvider;
 use Knp\Menu\Twig\Helper;
 use Knp\Menu\Twig\MenuExtension;
 use Knp\Menu\Util\MenuManipulator;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class KnpMenuServiceProvider implements ServiceProviderInterface
 {
@@ -88,13 +90,13 @@ class KnpMenuServiceProvider implements ServiceProviderInterface
                 $app['knp_menu.template'] = 'knp_menu.html.twig';
             }
 
-            $app['twig'] = $app->share($app->extend('twig', function (\Twig_Environment $twig) use ($app) {
+            $app['twig'] = $app->share($app->extend('twig', function (Environment $twig) use ($app) {
                 $twig->addExtension($app['knp_menu.twig_extension']);
 
                 return $twig;
             }));
 
-            $app['twig.loader.filesystem'] = $app->share($app->extend('twig.loader.filesystem', function (\Twig_Loader_Filesystem $loader) use ($app) {
+            $app['twig.loader.filesystem'] = $app->share($app->extend('twig.loader.filesystem', function (FilesystemLoader $loader) use ($app) {
                 $loader->addPath(__DIR__.'/../../Resources/views');
 
                 return $loader;

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -4,23 +4,24 @@ namespace Knp\Menu\Renderer;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
+use Twig\Environment;
 
 class TwigRenderer implements RendererInterface
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $environment;
     private $matcher;
     private $defaultOptions;
 
     /**
-     * @param \Twig_Environment $environment
-     * @param string            $template
-     * @param MatcherInterface  $matcher
-     * @param array             $defaultOptions
+     * @param Environment      $environment
+     * @param string           $template
+     * @param MatcherInterface $matcher
+     * @param array            $defaultOptions
      */
-    public function __construct(\Twig_Environment $environment, $template, MatcherInterface $matcher, array $defaultOptions = array())
+    public function __construct(Environment $environment, $template, MatcherInterface $matcher, array $defaultOptions = array())
     {
         $this->environment = $environment;
         $this->matcher = $matcher;

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -5,8 +5,12 @@ namespace Knp\Menu\Twig;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Util\MenuManipulator;
 use Knp\Menu\Matcher\MatcherInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
 
-class MenuExtension extends \Twig_Extension
+class MenuExtension extends AbstractExtension
 {
     private $helper;
     private $matcher;
@@ -25,25 +29,25 @@ class MenuExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-             new \Twig_SimpleFunction('knp_menu_get', array($this, 'get')),
-             new \Twig_SimpleFunction('knp_menu_render', array($this, 'render'), array('is_safe' => array('html'))),
-             new \Twig_SimpleFunction('knp_menu_get_breadcrumbs_array', array($this, 'getBreadcrumbsArray')),
-             new \Twig_SimpleFunction('knp_menu_get_current_item', array($this, 'getCurrentItem')),
+             new TwigFunction('knp_menu_get', array($this, 'get')),
+             new TwigFunction('knp_menu_render', array($this, 'render'), array('is_safe' => array('html'))),
+             new TwigFunction('knp_menu_get_breadcrumbs_array', array($this, 'getBreadcrumbsArray')),
+             new TwigFunction('knp_menu_get_current_item', array($this, 'getCurrentItem')),
         );
     }
 
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('knp_menu_as_string', array($this, 'pathAsString')),
+            new TwigFilter('knp_menu_as_string', array($this, 'pathAsString')),
         );
     }
 
     public function getTests()
     {
         return array(
-            new \Twig_SimpleTest('knp_menu_current', array($this, 'isCurrent')),
-            new \Twig_SimpleTest('knp_menu_ancestor', array($this, 'isAncestor')),
+            new TwigTest('knp_menu_current', array($this, 'isCurrent')),
+            new TwigTest('knp_menu_ancestor', array($this, 'isAncestor')),
         );
     }
     

--- a/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
@@ -6,16 +6,18 @@ use Knp\Menu\Renderer\TwigRenderer;
 use Knp\Menu\MenuItem;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\Matcher\MatcherInterface;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class TwigRendererTest extends AbstractRendererTest
 {
     public function createRenderer(MatcherInterface $matcher)
     {
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists(Environment::class)) {
             $this->markTestSkipped('Twig is not available');
         }
-        $loader = new \Twig_Loader_Filesystem(__DIR__.'/../../../../../src/Knp/Menu/Resources/views');
-        $environment = new \Twig_Environment($loader);
+        $loader = new FilesystemLoader(__DIR__.'/../../../../../src/Knp/Menu/Resources/views');
+        $environment = new Environment($loader);
         $renderer = new TwigRenderer($environment, 'knp_menu.html.twig', $matcher, array('compressed' => true));
 
         return $renderer;

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -4,12 +4,15 @@ namespace Knp\Menu\Tests\Twig;
 
 use Knp\Menu\Twig\MenuExtension;
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Template;
 
 class MenuExtensionTest extends TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists(Environment::class)) {
             $this->markTestSkipped('Twig is not available');
         }
     }
@@ -187,12 +190,12 @@ class MenuExtensionTest extends TestCase
      * @param string                $template
      * @param \Knp\Menu\Twig\Helper $helper
      *
-     * @return \Twig_Template
+     * @return Template
      */
     private function getTemplate($template, $helper, $matcher = null, $menuManipulator = null)
     {
-        $loader = new \Twig_Loader_Array(array('index' => $template));
-        $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
+        $loader = new ArrayLoader(array('index' => $template));
+        $twig = new Environment($loader, array('debug' => true, 'cache' => false));
         $twig->addExtension(new MenuExtension($helper, $matcher, $menuManipulator));
 
         return $twig->loadTemplate('index');


### PR DESCRIPTION
Hello there. Following the news that using Twig's old PEAR-style classes [will trigger deprecation notices soon](https://symfony.com/blog/new-in-twig-namespaced-classes), I though it might be a good idea to switch this lovely codebase to the namespaced classes now.