### PR TITLE
Twig 2.7 support without deprecated. Used spaceless filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-foundation": "~2.4|~3.0|^4.0",
         "symfony/phpunit-bridge": "~3.3|^4.0",
         "symfony/routing": "~2.3|~3.0|^4.0",
-        "twig/twig":       "~1.16|~2.0"
+        "twig/twig": "~1.38|~2.7"
     },
     "suggest":      {
         "twig/twig":    "for the TwigRenderer and the integration with your templates"

--- a/src/Knp/Menu/Resources/views/knp_menu.html.twig
+++ b/src/Knp/Menu/Resources/views/knp_menu.html.twig
@@ -9,9 +9,7 @@
 {% endmacro %}
 
 {% block compressed_root %}
-{% spaceless %}
-{{ block('root') }}
-{% endspaceless %}
+{{ block('root')|spaceless }}
 {% endblock %}
 
 {% block root %}


### PR DESCRIPTION
Text deprecated:
https://github.com/twigphp/Twig/blob/1a05a525bbf320c50a105723c481df8156947eb8/lib/Twig/Node/Spaceless.php