### PR TITLE
explicitly add maintainers in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,11 +76,19 @@ to discover how KnpMenu will rock your world!
 
 Find all available documentation at [`doc/`][2].
 
+## Maintainers
+
+This library is maintained by the following people (alphabetically sorted) :
+
+- @derrabus
+- @garak
+- @stof
+
 ## Credits
 
 This bundle was originally ported from [ioMenuPlugin](http://github.com/weaverryan/ioMenuPlugin),
 a menu plugin for symfony1. It has since been developed by [KnpLabs](http://www.knplabs.com) and
-the Symfony community.
+the [Symfony community](https://github.com/KnpLabs/KnpMenu/graphs/contributors).
 
 [0]: doc/01-Basic-Menus.markdown
 [1]: doc/02-Twig-Integration.markdown


### PR DESCRIPTION
As stated in
https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance ,
we'd like to explicitly indicate who is maintaining the project, as the
KNP Labs organization is looking for maintainers.

Fixes #303 .

Thank you @stof, @garak, @derrabus :)

I hope you three are okay with these changes, and we'd like to thank you a lot for taking care of this project :hugs: !