### PR TITLE
cs fix

### DIFF
--- a/src/Knp/Menu/Factory/CoreExtension.php
+++ b/src/Knp/Menu/Factory/CoreExtension.php
@@ -18,7 +18,7 @@ class CoreExtension implements ExtensionInterface
      */
     public function buildOptions(array $options): array
     {
-        return array_merge(
+        return \array_merge(
             [
                 'uri' => null,
                 'label' => null,

--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -176,6 +176,7 @@ interface ItemInterface extends \ArrayAccess, \Countable, \IteratorAggregate
      * @param array                $options If creating a new item, the options passed to the factory for the item
      *
      * @return ItemInterface
+     *
      * @throws \InvalidArgumentException if the item is already in a tree
      */
     public function addChild(self $child, array $options = []): self;

--- a/src/Knp/Menu/Loader/ArrayLoader.php
+++ b/src/Knp/Menu/Loader/ArrayLoader.php
@@ -22,7 +22,7 @@ class ArrayLoader implements LoaderInterface
     public function load($data): ItemInterface
     {
         if (!$this->supports($data)) {
-            throw new \InvalidArgumentException(sprintf('Unsupported data. Expected an array but got ', is_object($data) ? get_class($data) : gettype($data)));
+            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected an array but got %s', \is_object($data) ? \get_class($data) : \gettype($data)));
         }
 
         return $this->fromArray($data);
@@ -30,7 +30,7 @@ class ArrayLoader implements LoaderInterface
 
     public function supports($data): bool
     {
-        return is_array($data);
+        return \is_array($data);
     }
 
     /**

--- a/src/Knp/Menu/Loader/LoaderInterface.php
+++ b/src/Knp/Menu/Loader/LoaderInterface.php
@@ -20,7 +20,7 @@ interface LoaderInterface
      *
      * @param mixed $data
      *
-     * @return boolean
+     * @return bool
      */
     public function supports($data): bool;
 }

--- a/src/Knp/Menu/Loader/NodeLoader.php
+++ b/src/Knp/Menu/Loader/NodeLoader.php
@@ -3,6 +3,7 @@
 namespace Knp\Menu\Loader;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\NodeInterface;
 
 class NodeLoader implements LoaderInterface
@@ -14,10 +15,10 @@ class NodeLoader implements LoaderInterface
         $this->factory = $factory;
     }
 
-    public function load($data)
+    public function load($data): ItemInterface
     {
         if (!$data instanceof NodeInterface) {
-            throw new \InvalidArgumentException(sprintf('Unsupported data. Expected Knp\Menu\NodeInterface but got %s', is_object($data) ? get_class($data) : gettype($data)));
+            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected Knp\Menu\NodeInterface but got %s', \is_object($data) ? \get_class($data) : \gettype($data)));
         }
 
         $item = $this->factory->createItem($data->getName(), $data->getOptions());
@@ -29,7 +30,7 @@ class NodeLoader implements LoaderInterface
         return $item;
     }
 
-    public function supports($data)
+    public function supports($data): bool
     {
         return $data instanceof NodeInterface;
     }

--- a/src/Knp/Menu/Matcher/Matcher.php
+++ b/src/Knp/Menu/Matcher/Matcher.php
@@ -40,7 +40,7 @@ class Matcher implements MatcherInterface
             }
         }
 
-        $current = (boolean) $current;
+        $current = (bool) $current;
         $this->cache[$item] = $current;
 
         return $current;

--- a/src/Knp/Menu/Matcher/MatcherInterface.php
+++ b/src/Knp/Menu/Matcher/MatcherInterface.php
@@ -14,7 +14,7 @@ interface MatcherInterface
      *
      * @param ItemInterface $item
      *
-     * @return boolean
+     * @return bool
      */
     public function isCurrent(ItemInterface $item): bool;
 

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -42,11 +42,11 @@ class RouteVoter implements VoterInterface
         $routes = (array) $item->getExtra('routes', []);
 
         foreach ($routes as $testedRoute) {
-            if (is_string($testedRoute)) {
+            if (\is_string($testedRoute)) {
                 $testedRoute = ['route' => $testedRoute];
             }
 
-            if (!is_array($testedRoute)) {
+            if (!\is_array($testedRoute)) {
                 throw new \InvalidArgumentException('Routes extra items must be strings or arrays.');
             }
 
@@ -67,7 +67,7 @@ class RouteVoter implements VoterInterface
                 return false;
             }
         } elseif (!empty($testedRoute['pattern'])) {
-            if (!preg_match($testedRoute['pattern'], $route)) {
+            if (!\preg_match($testedRoute['pattern'], $route)) {
                 return false;
             }
         } else {

--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -16,7 +16,7 @@ class MenuFactory implements FactoryInterface
     private $extensions = [];
 
     /**
-     * @var ExtensionInterface[]
+     * @var ExtensionInterface[]|null
      */
     private $sorted;
 
@@ -55,13 +55,13 @@ class MenuFactory implements FactoryInterface
     /**
      * Sorts the internal list of extensions by priority.
      *
-     * @return ExtensionInterface[]
+     * @return ExtensionInterface[]|null
      */
     private function getExtensions(): ?array
     {
         if (null === $this->sorted) {
-            krsort($this->extensions);
-            $this->sorted = !empty($this->extensions) ? call_user_func_array('array_merge', $this->extensions) : [];
+            \krsort($this->extensions);
+            $this->sorted = !empty($this->extensions) ? \call_user_func_array('array_merge', $this->extensions) : [];
         }
 
         return $this->sorted;

--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -9,78 +9,91 @@ class MenuItem implements ItemInterface
 {
     /**
      * Name of this menu item (used for id by parent menu)
+     *
      * @var string
      */
     protected $name;
 
     /**
      * Label to output, name is used by default
+     *
      * @var string|null
      */
     protected $label;
 
     /**
      * Attributes for the item link
+     *
      * @var array
      */
     protected $linkAttributes = [];
 
     /**
      * Attributes for the children list
+     *
      * @var array
      */
     protected $childrenAttributes = [];
 
     /**
      * Attributes for the item text
+     *
      * @var array
      */
     protected $labelAttributes = [];
 
     /**
      * Uri to use in the anchor tag
+     *
      * @var string|null
      */
     protected $uri;
 
     /**
      * Attributes for the item
+     *
      * @var array
      */
     protected $attributes = [];
 
     /**
      * Extra stuff associated to the item
+     *
      * @var array
      */
     protected $extras = [];
 
     /**
      * Whether the item is displayed
+     *
      * @var bool
      */
     protected $display = true;
 
     /**
      * Whether the children of the item are displayed
+     *
      * @var bool
      */
     protected $displayChildren = true;
 
     /**
      * Child items
+     *
      * @var ItemInterface[]
      */
     protected $children = [];
 
     /**
      * Parent item
+     *
      * @var ItemInterface|null
      */
     protected $parent;
 
     /**
      * whether the item is current. null means unknown
+     *
      * @var bool|null
      */
     protected $isCurrent;
@@ -137,13 +150,13 @@ class MenuItem implements ItemInterface
         $this->name = $name;
 
         if (null !== $parent) {
-            $names = array_keys($parent->getChildren());
-            $items = array_values($parent->getChildren());
+            $names = \array_keys($parent->getChildren());
+            $items = \array_values($parent->getChildren());
 
-            $offset = array_search($oldName, $names);
+            $offset = \array_search($oldName, $names);
             $names[$offset] = $name;
 
-            $parent->setChildren(array_combine($names, $items));
+            $parent->setChildren(\array_combine($names, $items));
         }
 
         return $this;
@@ -163,7 +176,7 @@ class MenuItem implements ItemInterface
 
     public function getLabel(): string
     {
-        return ($this->label !== null) ? $this->label : $this->name;
+        return (null !== $this->label) ? $this->label : $this->name;
     }
 
     public function setLabel(?string $label): ItemInterface
@@ -550,7 +563,7 @@ class MenuItem implements ItemInterface
             return true;
         }
 
-        $children = array_reverse($this->getParent()->getChildren());
+        $children = \array_reverse($this->getParent()->getChildren());
         foreach ($children as $child) {
             // loop until we find a visible menu. If its this menu, we're first
             if ($child->isDisplayed()) {

--- a/src/Knp/Menu/Provider/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Provider/ArrayAccessProvider.php
@@ -29,13 +29,13 @@ class ArrayAccessProvider implements MenuProviderInterface
     public function get(string $name, array $options = []): ItemInterface
     {
         if (!isset($this->menuIds[$name])) {
-            throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+            throw new \InvalidArgumentException(\sprintf('The menu "%s" is not defined.', $name));
         }
 
         $menu = $this->registry[$this->menuIds[$name]];
 
-        if (is_callable($menu)) {
-            $menu = call_user_func($menu, $options, $this->registry);
+        if (\is_callable($menu)) {
+            $menu = \call_user_func($menu, $options, $this->registry);
         }
 
         return $menu;

--- a/src/Knp/Menu/Provider/ChainProvider.php
+++ b/src/Knp/Menu/Provider/ChainProvider.php
@@ -24,7 +24,7 @@ class ChainProvider implements MenuProviderInterface
             }
         }
 
-        throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+        throw new \InvalidArgumentException(\sprintf('The menu "%s" is not defined.', $name));
     }
 
     public function has(string $name, array $options = []): bool

--- a/src/Knp/Menu/Provider/LazyProvider.php
+++ b/src/Knp/Menu/Provider/LazyProvider.php
@@ -23,20 +23,20 @@ class LazyProvider implements MenuProviderInterface
     public function get(string $name, array $options = []): ItemInterface
     {
         if (!isset($this->builders[$name])) {
-            throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+            throw new \InvalidArgumentException(\sprintf('The menu "%s" is not defined.', $name));
         }
 
         $builder = $this->builders[$name];
 
-        if (is_array($builder) && isset($builder[0]) && $builder[0] instanceof \Closure) {
+        if (\is_array($builder) && isset($builder[0]) && $builder[0] instanceof \Closure) {
             $builder[0] = $builder[0]();
         }
 
-        if (!is_callable($builder)) {
-            throw new \LogicException(sprintf('Invalid menu builder for "%s". A callable or a factory for an object callable are expected.', $name));
+        if (!\is_callable($builder)) {
+            throw new \LogicException(\sprintf('Invalid menu builder for "%s". A callable or a factory for an object callable are expected.', $name));
         }
 
-        return call_user_func($builder, $options);
+        return \call_user_func($builder, $options);
     }
 
     public function has($name, array $options = []): bool

--- a/src/Knp/Menu/Provider/LazyProvider.php
+++ b/src/Knp/Menu/Provider/LazyProvider.php
@@ -36,7 +36,7 @@ class LazyProvider implements MenuProviderInterface
             throw new \LogicException(\sprintf('Invalid menu builder for "%s". A callable or a factory for an object callable are expected.', $name));
         }
 
-        return \call_user_func($builder, $options);
+        return $builder($options);
     }
 
     public function has($name, array $options = []): bool

--- a/src/Knp/Menu/Provider/MenuProviderInterface.php
+++ b/src/Knp/Menu/Provider/MenuProviderInterface.php
@@ -13,6 +13,7 @@ interface MenuProviderInterface
      * @param array  $options
      *
      * @return ItemInterface
+     *
      * @throws \InvalidArgumentException if the menu does not exists
      */
     public function get(string $name, array $options = []): ItemInterface;
@@ -23,7 +24,7 @@ interface MenuProviderInterface
      * @param string $name
      * @param array  $options
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $name, array $options = []): bool;
 }

--- a/src/Knp/Menu/Provider/PsrProvider.php
+++ b/src/Knp/Menu/Provider/PsrProvider.php
@@ -23,7 +23,7 @@ class PsrProvider implements MenuProviderInterface
     public function get(string $name, array $options = []): ItemInterface
     {
         if (!$this->container->has($name)) {
-            throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+            throw new \InvalidArgumentException(\sprintf('The menu "%s" is not defined.', $name));
         }
 
         return $this->container->get($name);

--- a/src/Knp/Menu/Renderer/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Renderer/ArrayAccessProvider.php
@@ -30,7 +30,7 @@ class ArrayAccessProvider implements RendererProviderInterface
         }
 
         if (!isset($this->rendererIds[$name])) {
-            throw new \InvalidArgumentException(sprintf('The renderer "%s" is not defined.', $name));
+            throw new \InvalidArgumentException(\sprintf('The renderer "%s" is not defined.', $name));
         }
 
         return $this->registry[$this->rendererIds[$name]];

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -16,12 +16,12 @@ class ListRenderer extends Renderer implements RendererInterface
     /**
      * @param MatcherInterface $matcher
      * @param array            $defaultOptions
-     * @param string           $charset
+     * @param string|null      $charset
      */
-    public function __construct(MatcherInterface $matcher, array $defaultOptions = [], $charset = null)
+    public function __construct(MatcherInterface $matcher, array $defaultOptions = [], ?string $charset = null)
     {
         $this->matcher = $matcher;
-        $this->defaultOptions = array_merge([
+        $this->defaultOptions = \array_merge([
             'depth' => null,
             'matchingDepth' => null,
             'currentAsLink' => true,
@@ -41,7 +41,7 @@ class ListRenderer extends Renderer implements RendererInterface
 
     public function render(ItemInterface $item, array $options = []): string
     {
-        $options = array_merge($this->defaultOptions, $options);
+        $options = \array_merge($this->defaultOptions, $options);
 
         $html = $this->renderList($item, $item->getChildrenAttributes(), $options);
 
@@ -52,7 +52,7 @@ class ListRenderer extends Renderer implements RendererInterface
         return $html;
     }
 
-    protected function renderList(ItemInterface $item, array $attributes, array $options)
+    protected function renderList(ItemInterface $item, array $attributes, array $options): string
     {
         /**
          * Return an empty string if any of the following are true:
@@ -84,7 +84,7 @@ class ListRenderer extends Renderer implements RendererInterface
      *
      * @return string
      */
-    protected function renderChildren(ItemInterface $item, array $options)
+    protected function renderChildren(ItemInterface $item, array $options): string
     {
         // render children with a depth - 1
         if (null !== $options['depth']) {
@@ -114,7 +114,7 @@ class ListRenderer extends Renderer implements RendererInterface
      *
      * @return string
      */
-    protected function renderItem(ItemInterface $item, array $options)
+    protected function renderItem(ItemInterface $item, array $options): string
     {
         // if we don't have access or this item is marked to not be shown
         if (!$item->isDisplayed()) {
@@ -137,7 +137,7 @@ class ListRenderer extends Renderer implements RendererInterface
             $class[] = $options['lastClass'];
         }
 
-        if ($item->hasChildren() && $options['depth'] !== 0) {
+        if ($item->hasChildren() && 0 !== $options['depth']) {
             if (null !== $options['branch_class'] && $item->getDisplayChildren()) {
                 $class[] = $options['branch_class'];
             }
@@ -148,7 +148,7 @@ class ListRenderer extends Renderer implements RendererInterface
         // retrieve the attributes and put the final class string back on it
         $attributes = $item->getAttributes();
         if (!empty($class)) {
-            $attributes['class'] = implode(' ', $class);
+            $attributes['class'] = \implode(' ', $class);
         }
 
         // opening li tag
@@ -163,7 +163,7 @@ class ListRenderer extends Renderer implements RendererInterface
         $childrenClass[] = 'menu_level_'.$item->getLevel();
 
         $childrenAttributes = $item->getChildrenAttributes();
-        $childrenAttributes['class'] = implode(' ', $childrenClass);
+        $childrenAttributes['class'] = \implode(' ', $childrenClass);
 
         $html .= $this->renderList($item, $childrenAttributes, $options);
 
@@ -186,7 +186,7 @@ class ListRenderer extends Renderer implements RendererInterface
      *
      * @return string
      */
-    protected function renderLink(ItemInterface $item, array $options = [])
+    protected function renderLink(ItemInterface $item, array $options = []): string
     {
         if ($item->getUri() && (!$item->isCurrent() || $options['currentAsLink'])) {
             $text = $this->renderLinkElement($item, $options);
@@ -197,17 +197,17 @@ class ListRenderer extends Renderer implements RendererInterface
         return $this->format($text, 'link', $item->getLevel(), $options);
     }
 
-    protected function renderLinkElement(ItemInterface $item, array $options)
+    protected function renderLinkElement(ItemInterface $item, array $options): string
     {
-        return sprintf('<a href="%s"%s>%s</a>', $this->escape($item->getUri()), $this->renderHtmlAttributes($item->getLinkAttributes()), $this->renderLabel($item, $options));
+        return \sprintf('<a href="%s"%s>%s</a>', $this->escape($item->getUri()), $this->renderHtmlAttributes($item->getLinkAttributes()), $this->renderLabel($item, $options));
     }
 
-    protected function renderSpanElement(ItemInterface $item, array $options)
+    protected function renderSpanElement(ItemInterface $item, array $options): string
     {
-        return sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $this->renderLabel($item, $options));
+        return \sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $this->renderLabel($item, $options));
     }
 
-    protected function renderLabel(ItemInterface $item, array $options)
+    protected function renderLabel(ItemInterface $item, array $options): string
     {
         if ($options['allow_safe_labels'] && $item->getExtra('safe_label', false)) {
             return $item->getLabel();
@@ -221,14 +221,14 @@ class ListRenderer extends Renderer implements RendererInterface
      * spacing and line-breaking so that the particular thing being rendered
      * makes up its part in a fully-rendered and spaced menu.
      *
-     * @param string  $html    The html to render in an (un)formatted way
-     * @param string  $type    The type [ul,link,li] of thing being rendered
-     * @param integer $level
-     * @param array   $options
+     * @param string $html    The html to render in an (un)formatted way
+     * @param string $type    The type [ul,link,li] of thing being rendered
+     * @param int    $level
+     * @param array  $options
      *
      * @return string
      */
-    protected function format($html, $type, $level, array $options)
+    protected function format(string $html, string $type, int $level, array $options): string
     {
         if ($options['compressed']) {
             return $html;

--- a/src/Knp/Menu/Renderer/PsrProvider.php
+++ b/src/Knp/Menu/Renderer/PsrProvider.php
@@ -34,7 +34,7 @@ class PsrProvider implements RendererProviderInterface
         }
 
         if (!$this->container->has($name)) {
-            throw new \InvalidArgumentException(sprintf('The renderer "%s" is not defined.', $name));
+            throw new \InvalidArgumentException(\sprintf('The renderer "%s" is not defined.', $name));
         }
 
         return $this->container->get($name);

--- a/src/Knp/Menu/Renderer/Renderer.php
+++ b/src/Knp/Menu/Renderer/Renderer.php
@@ -27,10 +27,10 @@ abstract class Renderer
     protected function renderHtmlAttribute(string $name, $value): string
     {
         if (true === $value) {
-            return sprintf('%s="%s"', $name, $this->escape($name));
+            return \sprintf('%s="%s"', $name, $this->escape($name));
         }
 
-        return sprintf('%s="%s"', $name, $this->escape($value));
+        return \sprintf('%s="%s"', $name, $this->escape($value));
     }
 
     /**
@@ -42,7 +42,7 @@ abstract class Renderer
      */
     protected function renderHtmlAttributes(array $attributes): string
     {
-        return implode('', array_map([$this, 'htmlAttributesCallback'], array_keys($attributes), array_values($attributes)));
+        return \implode('', \array_map([$this, 'htmlAttributesCallback'], \array_keys($attributes), \array_values($attributes)));
     }
 
     /**
@@ -73,7 +73,7 @@ abstract class Renderer
      */
     protected function escape(string $value): string
     {
-        return $this->fixDoubleEscape(htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $this->charset));
+        return $this->fixDoubleEscape(\htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $this->charset));
     }
 
     /**
@@ -85,7 +85,7 @@ abstract class Renderer
      */
     protected function fixDoubleEscape(string $escaped): string
     {
-        return preg_replace('/&amp;([a-z]+|(#\d+)|(#x[\da-f]+));/i', '&$1;', $escaped);
+        return \preg_replace('/&amp;([a-z]+|(#\d+)|(#x[\da-f]+));/i', '&$1;', $escaped);
     }
 
     /**

--- a/src/Knp/Menu/Renderer/RendererProviderInterface.php
+++ b/src/Knp/Menu/Renderer/RendererProviderInterface.php
@@ -12,6 +12,7 @@ interface RendererProviderInterface
      * @param string|null $name
      *
      * @return RendererInterface
+     *
      * @throws \InvalidArgumentException if the renderer does not exists
      */
     public function get(?string $name = null): RendererInterface;
@@ -21,7 +22,7 @@ interface RendererProviderInterface
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $name): bool;
 }

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -25,7 +25,7 @@ class TwigRenderer implements RendererInterface
     {
         $this->environment = $environment;
         $this->matcher = $matcher;
-        $this->defaultOptions = array_merge([
+        $this->defaultOptions = \array_merge([
             'depth' => null,
             'matchingDepth' => null,
             'currentAsLink' => true,
@@ -44,7 +44,7 @@ class TwigRenderer implements RendererInterface
 
     public function render(ItemInterface $item, array $options = []): string
     {
-        $options = array_merge($this->defaultOptions, $options);
+        $options = \array_merge($this->defaultOptions, $options);
 
         $html = $this->environment->render($options['template'], ['item' => $item, 'options' => $options, 'matcher' => $this->matcher]);
 

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -10,7 +10,6 @@ use Knp\Menu\Util\MenuManipulator;
 
 /**
  * Helper class containing logic to retrieve and render menus from templating engines
- *
  */
 class Helper
 {
@@ -57,14 +56,14 @@ class Helper
             $menu = $this->menuProvider->get($menuName, $options);
 
             if (!$menu instanceof ItemInterface) {
-                throw new \LogicException(sprintf('The menu "%s" exists, but is not a valid menu item object. Check where you created the menu to be sure it returns an ItemInterface object.', $menuName));
+                throw new \LogicException(\sprintf('The menu "%s" exists, but is not a valid menu item object. Check where you created the menu to be sure it returns an ItemInterface object.', $menuName));
             }
         }
 
         foreach ($path as $child) {
             $menu = $menu->getChild($child);
             if (null === $menu) {
-                throw new \InvalidArgumentException(sprintf('The menu has no child named "%s"', $child));
+                throw new \InvalidArgumentException(\sprintf('The menu has no child named "%s"', $child));
             }
         }
 
@@ -87,7 +86,7 @@ class Helper
      *
      * @throws \InvalidArgumentException
      */
-    public function render($menu, array $options = [], $renderer =  null)
+    public function render($menu, array $options = [], $renderer = null)
     {
         $menu = $this->castMenu($menu);
 
@@ -109,7 +108,7 @@ class Helper
      *   * ['subItem1', 'subItem2']
      *   * [['label' => 'subItem1', 'url' => '@homepage'], ['label' => 'subItem2']]
      *
-     * @param mixed $item
+     * @param mixed $menu
      * @param mixed $subItem A string or array to append onto the end of the array
      *
      * @return array
@@ -152,12 +151,12 @@ class Helper
     {
         if (!$menu instanceof ItemInterface) {
             $path = [];
-            if (is_array($menu)) {
+            if (\is_array($menu)) {
                 if (empty($menu)) {
                     throw new \InvalidArgumentException('The array cannot be empty');
                 }
                 $path = $menu;
-                $menu = array_shift($path);
+                $menu = \array_shift($path);
             }
 
             return $this->get($menu, $path);

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -16,9 +16,6 @@ class MenuExtension extends AbstractExtension
     private $matcher;
     private $menuManipulator;
 
-    /**
-     * @param Helper $helper
-     */
     public function __construct(Helper $helper, MatcherInterface $matcher = null, MenuManipulator $menuManipulator = null)
     {
         $this->helper = $helper;
@@ -26,7 +23,7 @@ class MenuExtension extends AbstractExtension
         $this->menuManipulator = $menuManipulator;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
              new TwigFunction('knp_menu_get', [$this, 'get']),
@@ -36,21 +33,21 @@ class MenuExtension extends AbstractExtension
         ];
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('knp_menu_as_string', [$this, 'pathAsString']),
         ];
     }
 
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest('knp_menu_current', [$this, 'isCurrent']),
             new TwigTest('knp_menu_ancestor', [$this, 'isAncestor']),
         ];
     }
-    
+
     /**
      * Retrieves an item following a path in the tree.
      *
@@ -60,7 +57,7 @@ class MenuExtension extends AbstractExtension
      *
      * @return ItemInterface
      */
-    public function get($menu, array $path = [], array $options = [])
+    public function get($menu, array $path = [], array $options = []): ItemInterface
     {
         return $this->helper->get($menu, $path, $options);
     }
@@ -74,7 +71,7 @@ class MenuExtension extends AbstractExtension
      *
      * @return string
      */
-    public function render($menu, array $options = [], $renderer = null)
+    public function render($menu, array $options = [], $renderer = null): string
     {
         return $this->helper->render($menu, $options, $renderer);
     }
@@ -82,12 +79,12 @@ class MenuExtension extends AbstractExtension
     /**
      * Returns an array ready to be used for breadcrumbs.
      *
-     * @param ItemInterface|array|string $item
+     * @param ItemInterface|array|string $menu
      * @param string|array|null          $subItem
      *
      * @return array
      */
-    public function getBreadcrumbsArray($menu, $subItem = null)
+    public function getBreadcrumbsArray($menu, $subItem = null): array
     {
         return $this->helper->getBreadcrumbsArray($menu, $subItem);
     }
@@ -99,7 +96,7 @@ class MenuExtension extends AbstractExtension
      *
      * @return ItemInterface
      */
-    public function getCurrentItem($menu)
+    public function getCurrentItem($menu): ItemInterface
     {
         $rootItem = $this->get($menu);
 
@@ -117,12 +114,12 @@ class MenuExtension extends AbstractExtension
      *
      * e.g. Top Level > Second Level > This menu
      *
-     * @param ItemInterface $item
+     * @param ItemInterface $menu
      * @param string        $separator
      *
      * @return string
      */
-    public function pathAsString(ItemInterface $menu, $separator = ' > ')
+    public function pathAsString(ItemInterface $menu, $separator = ' > '): string
     {
         if (null === $this->menuManipulator) {
             throw new \BadMethodCallException('The menu manipulator must be set to get the breadcrumbs array');
@@ -136,9 +133,9 @@ class MenuExtension extends AbstractExtension
      *
      * @param ItemInterface $item
      *
-     * @return boolean
+     * @return bool
      */
-    public function isCurrent(ItemInterface $item)
+    public function isCurrent(ItemInterface $item): bool
     {
         if (null === $this->matcher) {
             throw new \BadMethodCallException('The matcher must be set to get the breadcrumbs array');
@@ -151,24 +148,16 @@ class MenuExtension extends AbstractExtension
      * Checks whether an item is the ancestor of a current item.
      *
      * @param ItemInterface $item
-     * @param integer       $depth The max depth to look for the item
+     * @param int|null      $depth The max depth to look for the item
      *
-     * @return boolean
+     * @return bool
      */
-    public function isAncestor(ItemInterface $item, $depth = null)
+    public function isAncestor(ItemInterface $item, ?int $depth = null): bool
     {
         if (null === $this->matcher) {
             throw new \BadMethodCallException('The matcher must be set to get the breadcrumbs array');
         }
 
         return $this->matcher->isAncestor($item, $depth);
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'knp_menu';
     }
 }

--- a/src/Knp/Menu/Util/MenuManipulator.php
+++ b/src/Knp/Menu/Util/MenuManipulator.php
@@ -10,7 +10,7 @@ class MenuManipulator
      * Moves item to specified position. Rearrange siblings accordingly.
      *
      * @param ItemInterface $item
-     * @param integer       $position Position to move child to.
+     * @param int           $position Position to move child to.
      */
     public function moveToPosition(ItemInterface $item, $position): void
     {
@@ -21,20 +21,20 @@ class MenuManipulator
      * Moves child to specified position. Rearrange other children accordingly.
      *
      * @param ItemInterface $item
-     * @param ItemInterface $child    Child to move.
-     * @param integer       $position Position to move child to.
+     * @param ItemInterface $child    Child to move
+     * @param int           $position Position to move child to
      */
     public function moveChildToPosition(ItemInterface $item, ItemInterface $child, $position): void
     {
         $name = $child->getName();
-        $order = array_keys($item->getChildren());
+        $order = \array_keys($item->getChildren());
 
-        $oldPosition = array_search($name, $order);
+        $oldPosition = \array_search($name, $order);
         unset($order[$oldPosition]);
 
-        $order = array_values($order);
+        $order = \array_values($order);
 
-        array_splice($order, $position, 0, $name);
+        \array_splice($order, $position, 0, $name);
         $item->reorderChildren($order);
     }
 
@@ -84,26 +84,26 @@ class MenuManipulator
      */
     public function slice(ItemInterface $item, $offset, $length = null)
     {
-        $names = array_keys($item->getChildren());
+        $names = \array_keys($item->getChildren());
         if ($offset instanceof ItemInterface) {
             $offset = $offset->getName();
         }
-        if (!is_numeric($offset)) {
-            $offset = array_search($offset, $names);
+        if (!\is_numeric($offset)) {
+            $offset = \array_search($offset, $names);
         }
 
         if (null !== $length) {
             if ($length instanceof ItemInterface) {
                 $length = $length->getName();
             }
-            if (!is_numeric($length)) {
-                $index = array_search($length, $names);
+            if (!\is_numeric($length)) {
+                $index = \array_search($length, $names);
                 $length = ($index < $offset) ? 0 : $index - $offset;
             }
         }
 
         $slicedItem = $item->copy();
-        $children = array_slice($slicedItem->getChildren(), $offset, $length);
+        $children = \array_slice($slicedItem->getChildren(), $offset, $length);
         $slicedItem->setChildren($children);
 
         return $slicedItem;
@@ -137,7 +137,7 @@ class MenuManipulator
      */
     public function callRecursively(ItemInterface $item, $method, $arguments = []): void
     {
-        call_user_func_array([$item, $method], $arguments);
+        \call_user_func_array([$item, $method], $arguments);
 
         foreach ($item->getChildren() as $child) {
             $this->callRecursively($child, $method, $arguments);
@@ -163,12 +163,12 @@ class MenuManipulator
             $children[] = $obj->getLabel();
         } while ($obj = $obj->getParent());
 
-        return implode($separator, array_reverse($children));
+        return \implode($separator, \array_reverse($children));
     }
 
     /**
      * @param ItemInterface $item
-     * @param integer|null  $depth the depth until which children should be exported (null means unlimited)
+     * @param int|null      $depth the depth until which children should be exported (null means unlimited)
      *
      * @return array
      */
@@ -236,7 +236,7 @@ class MenuManipulator
             return $breadcrumbs;
         }
 
-        if (!is_array($subItem) && !$subItem instanceof \Traversable) {
+        if (!\is_array($subItem) && !$subItem instanceof \Traversable) {
             $subItem = [$subItem];
         }
 
@@ -246,11 +246,11 @@ class MenuManipulator
                     $value = $this->getBreadcrumbsItem($value);
                     break;
 
-                case is_array($value):
+                case \is_array($value):
                     // Assume we already have the appropriate array format for the element
                     break;
 
-                case is_integer($key) && is_string($value):
+                case \is_int($key) && \is_string($value):
                     $value = [
                         'label' => (string) $value,
                         'uri' => null,
@@ -258,7 +258,7 @@ class MenuManipulator
                     ];
                     break;
 
-                case is_scalar($value):
+                case \is_scalar($value):
                     $value = [
                         'label' => (string) $key,
                         'uri' => (string) $value,
@@ -275,7 +275,7 @@ class MenuManipulator
                     break;
 
                 default:
-                    throw new \InvalidArgumentException(sprintf('Invalid value supplied for the key "%s". It should be an item, an array or a scalar', $key));
+                    throw new \InvalidArgumentException(\sprintf('Invalid value supplied for the key "%s". It should be an item, an array or a scalar', $key));
             }
 
             $breadcrumbs[] = $value;
@@ -292,7 +292,7 @@ class MenuManipulator
             $breadcrumb[] = $this->getBreadcrumbsItem($item);
         } while ($item = $item->getParent());
 
-        return array_reverse($breadcrumb);
+        return \array_reverse($breadcrumb);
     }
 
     private function getBreadcrumbsItem(ItemInterface $item)

--- a/src/Knp/Menu/Util/MenuManipulator.php
+++ b/src/Knp/Menu/Util/MenuManipulator.php
@@ -137,7 +137,7 @@ class MenuManipulator
      */
     public function callRecursively(ItemInterface $item, $method, $arguments = []): void
     {
-        \call_user_func_array([$item, $method], $arguments);
+        $item->$method(...$arguments);
 
         foreach ($item->getChildren() as $child) {
             $this->callRecursively($child, $method, $arguments);


### PR DESCRIPTION
this is a bunch of fix in coding standard, extracted from previous
PR for new v3 release. It includes:

* explicit root functions
* fix int/bool names (e.g. instead of integer/boolean)
* fix some phpdoc missing lines
* fix some non-yoda comparisons
* sort imports
* add some forgotten type hints/return types
* remove some irrelevant spaces
* fix some phpdoc wrong names