### PR TITLE
fix parameter hinting

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -179,7 +179,7 @@ interface ItemInterface extends \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @throws \InvalidArgumentException if the item is already in a tree
      */
-    public function addChild(self $child, array $options = []): self;
+    public function addChild($child, array $options = []): self;
 
     /**
      * Returns the child menu identified by the given name


### PR DESCRIPTION
I was wrong in type-hinting first parameter here, since it's allowed to pass a `string` instead of an `ItemInterface`