### PR TITLE
Fix `currentAsLink` not working when determining state via voters.

### DIFF
--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -188,7 +188,7 @@ class ListRenderer extends Renderer implements RendererInterface
      */
     protected function renderLink(ItemInterface $item, array $options = []): string
     {
-        if ($item->getUri() && (!$item->isCurrent() || $options['currentAsLink'])) {
+        if ($item->getUri() && (!$this->matcher->isCurrent($item) || $options['currentAsLink'])) {
             $text = $this->renderLinkElement($item, $options);
         } else {
             $text = $this->renderSpanElement($item, $options);

--- a/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
@@ -4,6 +4,7 @@ namespace Knp\Menu\Tests\Renderer;
 
 use Knp\Menu\Matcher\Matcher;
 use Knp\Menu\Matcher\MatcherInterface;
+use Knp\Menu\Matcher\Voter\UriVoter;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
 use Knp\Menu\Tests\MenuTestCase;
@@ -223,11 +224,35 @@ abstract class AbstractRendererTest extends MenuTestCase
         $this->assertEquals($rendered, $this->renderer->render($menu));
     }
 
+    public function testRenderWithCurrentItemAsLinkUsingMatcherWithVoters(): void
+    {
+        $matcher = new Matcher([new UriVoter('/about')]);
+        $this->renderer = $this->createRenderer($matcher);
+
+        $menu = new MenuItem('test', new MenuFactory());
+        $menu->addChild('About', ['uri' => '/about']);
+
+        $rendered = '<ul><li class="current first last"><a href="/about">About</a></li></ul>';
+        $this->assertEquals($rendered, $this->renderer->render($menu));
+    }
+
     public function testRenderWithCurrentItemNotAsLink(): void
     {
         $menu = new MenuItem('test', new MenuFactory());
         $about = $menu->addChild('About', ['uri' => '/about']);
         $about->setCurrent(true);
+
+        $rendered = '<ul><li class="current first last"><span>About</span></li></ul>';
+        $this->assertEquals($rendered, $this->renderer->render($menu, ['currentAsLink' => false]));
+    }
+
+    public function testRenderWithCurrentItemNotAsLinkUsingMatcherWithVoters(): void
+    {
+        $matcher = new Matcher([new UriVoter('/about')]);
+        $this->renderer = $this->createRenderer($matcher);
+
+        $menu = new MenuItem('test', new MenuFactory());
+        $menu->addChild('About', ['uri' => '/about']);
 
         $rendered = '<ul><li class="current first last"><span>About</span></li></ul>';
         $this->assertEquals($rendered, $this->renderer->render($menu, ['currentAsLink' => false]));


### PR DESCRIPTION
It seems that this was overlooked when matchers were introduced with #49.

Testing wise this is kinda covered by `\Knp\Menu\Tests\Renderer\AbstractRendererTest::testRenderWithCurrentItemAsLink()` and `\Knp\Menu\Tests\Renderer\AbstractRendererTest::testRenderWithCurrentItemNotAsLink()`. Please let me know if you'd like me to add additional tests for this.

Test faillures for `DEPENDENCIES=dev` seem unrelated.