### PR TITLE
Add generics notation to MenuInterface

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -9,7 +9,7 @@ namespace Knp\Menu;
  * most of the time by default.
  * Originally taken from ioMenuPlugin (http://github.com/weaverryan/ioMenuPlugin)
  *
- * @extends \IteratorAggregate<self>
+ * @extends \IteratorAggregate<string, self>
  */
 interface ItemInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 {

--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -8,6 +8,8 @@ namespace Knp\Menu;
  * It roughly represents a single <li> tag and is what you should interact with
  * most of the time by default.
  * Originally taken from ioMenuPlugin (http://github.com/weaverryan/ioMenuPlugin)
+ *
+ * @extends \IteratorAggregate<self>
  */
 interface ItemInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 {


### PR DESCRIPTION
Solves errors by PHPStan similar to:

![image](https://user-images.githubusercontent.com/362286/80252072-ed141280-8676-11ea-999e-51dc453938c5.png)
