### PR TITLE
Use a stable php 7.4 build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 php:
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
     - nightly
 
 env:
@@ -22,7 +22,7 @@ matrix:
     include:
         - php: 7.2
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
-        - php: 7.4snapshot
+        - php: 7.4
           env: DEPENDENCIES=dev
     allow_failures:
         - php: nightly


### PR DESCRIPTION
I noticed that we're still using `7.4snapshot` on Travis. I think, we can switch to stable php 7.4 releases now. 😃 