### PR TITLE
Little refactoring Twig\Helper. The method castMenu inject array opti…

### DIFF
--- a/src/Knp/Menu/AbstractFactory.php
+++ b/src/Knp/Menu/AbstractFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Knp\Menu;
+
+use Knp\Menu\Factory\CoreExtension;
+use Knp\Menu\Factory\ExtensionInterface;
+
+/**
+ * Class AbstractFactory
+ *
+ * @package Knp\Menu
+ */
+abstract class AbstractFactory implements FactoryInterface
+{
+    /**
+     * @var array[]
+     */
+    protected $extensions = [];
+
+    /**
+     * @var ExtensionInterface[]|null
+     */
+    protected $sorted;
+
+    public function __construct()
+    {
+        $this->addExtension(new CoreExtension(), -10);
+    }
+
+    public function createItem(string $name, array $options = []): ItemInterface
+    {
+        foreach ($this->getExtensions() as $extension) {
+            $options = $extension->buildOptions($options);
+        }
+
+        $item = $this->getMenuItem($name);
+
+        foreach ($this->getExtensions() as $extension) {
+            $extension->buildItem($item, $options);
+        }
+
+        return $item;
+    }
+
+    abstract protected function getMenuItem($name);
+
+    /**
+     * Adds a factory extension
+     *
+     * @param ExtensionInterface $extension
+     * @param int                $priority
+     */
+    public function addExtension(ExtensionInterface $extension, int $priority = 0): void
+    {
+        $this->extensions[$priority][] = $extension;
+        $this->sorted = null;
+    }
+
+    /**
+     * Sorts the internal list of extensions by priority.
+     *
+     * @return ExtensionInterface[]|null
+     */
+    private function getExtensions(): ?array
+    {
+        if (null === $this->sorted) {
+            \krsort($this->extensions);
+            $this->sorted = !empty($this->extensions) ? \call_user_func_array('array_merge', $this->extensions) : [];
+        }
+
+        return $this->sorted;
+    }
+}

--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -8,62 +8,10 @@ use Knp\Menu\Factory\ExtensionInterface;
 /**
  * Factory to create a menu from a tree
  */
-class MenuFactory implements FactoryInterface
+class MenuFactory extends AbstractFactory
 {
-    /**
-     * @var array[]
-     */
-    private $extensions = [];
-
-    /**
-     * @var ExtensionInterface[]|null
-     */
-    private $sorted;
-
-    public function __construct()
+    protected function getMenuItem($name)
     {
-        $this->addExtension(new CoreExtension(), -10);
-    }
-
-    public function createItem(string $name, array $options = []): ItemInterface
-    {
-        foreach ($this->getExtensions() as $extension) {
-            $options = $extension->buildOptions($options);
-        }
-
-        $item = new MenuItem($name, $this);
-
-        foreach ($this->getExtensions() as $extension) {
-            $extension->buildItem($item, $options);
-        }
-
-        return $item;
-    }
-
-    /**
-     * Adds a factory extension
-     *
-     * @param ExtensionInterface $extension
-     * @param int                $priority
-     */
-    public function addExtension(ExtensionInterface $extension, int $priority = 0): void
-    {
-        $this->extensions[$priority][] = $extension;
-        $this->sorted = null;
-    }
-
-    /**
-     * Sorts the internal list of extensions by priority.
-     *
-     * @return ExtensionInterface[]|null
-     */
-    private function getExtensions(): ?array
-    {
-        if (null === $this->sorted) {
-            \krsort($this->extensions);
-            $this->sorted = !empty($this->extensions) ? \call_user_func_array('array_merge', $this->extensions) : [];
-        }
-
-        return $this->sorted;
+        return new MenuItem($name, $this);
     }
 }

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -88,7 +88,7 @@ class Helper
      */
     public function render($menu, array $options = [], $renderer = null)
     {
-        $menu = $this->castMenu($menu);
+        $menu = $this->castMenu($menu, $options);
 
         return $this->rendererProvider->get($renderer)->render($menu, $options);
     }
@@ -144,10 +144,11 @@ class Helper
 
     /**
      * @param ItemInterface|array|string $menu
+     * @param array                      $options
      *
      * @return ItemInterface
      */
-    private function castMenu($menu)
+    private function castMenu($menu, $options = [])
     {
         if (!$menu instanceof ItemInterface) {
             $path = [];
@@ -159,7 +160,7 @@ class Helper
                 $menu = \array_shift($path);
             }
 
-            return $this->get($menu, $path);
+            return $this->get($menu, $path, $options);
         }
 
         return $menu;


### PR DESCRIPTION
Hi
The method castMenu inject array options into Menu Builders
Now you could easy use different options to generate Menu with Menu Builders 
{{ knp_menu_render('main', {'group': constant('Evrinoma\\MenuBundle\\Menu\\MenuInterface::DEFAULT_GROUP') }) }}
Test pass on php74

Signed-off-by: Nikolay Nikolaev <evrinoma@gmail.com>