### PR TITLE
improve tests

### DIFF
--- a/src/Knp/Menu/Renderer/Renderer.php
+++ b/src/Knp/Menu/Renderer/Renderer.php
@@ -73,7 +73,7 @@ abstract class Renderer
      */
     protected function escape(string $value): string
     {
-        return $this->fixDoubleEscape(\htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $this->charset));
+        return $this->fixDoubleEscape(\htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, $this->charset));
     }
 
     /**

--- a/tests/Knp/Menu/Tests/Factory/CoreExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Factory/CoreExtensionTest.php
@@ -74,16 +74,15 @@ final class CoreExtensionTest extends TestCase
         $this->assertEquals('original value', $item->getExtra('test1'));
     }
 
-    private function getExtension()
+    private function getExtension(): CoreExtension
     {
         return new CoreExtension();
     }
 
-    private function createItem($name)
+    private function createItem($name): MenuItem
     {
         $factory = new MenuFactory();
-        $item = new MenuItem($name, $factory);
 
-        return $item;
+        return new MenuItem($name, $factory);
     }
 }

--- a/tests/Knp/Menu/Tests/Integration/Symfony/RoutingExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Integration/Symfony/RoutingExtensionTest.php
@@ -8,16 +8,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class RoutingExtensionTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!\interface_exists('Symfony\Component\Routing\Generator\UrlGeneratorInterface')) {
-            $this->markTestSkipped('The Symfony Routing component is not available');
-        }
-    }
-
     public function testCreateItemWithRoute(): void
     {
-        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $generator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
         $generator->expects($this->once())
             ->method('generate')
             ->with('homepage', [], UrlGeneratorInterface::ABSOLUTE_PATH)
@@ -34,7 +27,7 @@ final class RoutingExtensionTest extends TestCase
 
     public function testCreateItemWithRouteAndParameters(): void
     {
-        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $generator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
         $generator->expects($this->once())
             ->method('generate')
             ->with('homepage', ['id' => 12], UrlGeneratorInterface::ABSOLUTE_PATH)
@@ -50,7 +43,7 @@ final class RoutingExtensionTest extends TestCase
 
     public function testCreateItemWithAbsoluteRoute(): void
     {
-        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $generator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
         $generator->expects($this->once())
             ->method('generate')
             ->with('homepage', [], UrlGeneratorInterface::ABSOLUTE_URL)
@@ -66,7 +59,7 @@ final class RoutingExtensionTest extends TestCase
 
     public function testCreateItemAppendsRouteUnderExtras(): void
     {
-        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $generator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
 
         $extension = new RoutingExtension($generator);
 

--- a/tests/Knp/Menu/Tests/Iterator/IteratorTest.php
+++ b/tests/Knp/Menu/Tests/Iterator/IteratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests\Iterator;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Iterator\RecursiveItemIterator;
 use Knp\Menu\Tests\MenuTestCase;
 
@@ -20,7 +21,7 @@ final class IteratorTest extends MenuTestCase
     public function testRecursiveIterator(): void
     {
         // Adding an item which does not provide a RecursiveIterator to be sure it works properly.
-        $child = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $child = $this->getMockBuilder(ItemInterface::class)->getMock();
         $child->expects($this->any())
             ->method('getName')
             ->willReturn('Foo');

--- a/tests/Knp/Menu/Tests/Loader/ArrayLoaderTest.php
+++ b/tests/Knp/Menu/Tests/Loader/ArrayLoaderTest.php
@@ -84,16 +84,18 @@ final class ArrayLoaderTest extends TestCase
     }
 
     /**
+     * @param string|array $data
+     *
      * @dataProvider provideSupportingData
      */
-    public function testSupports($data, $expected): void
+    public function testSupports($data, bool $expected): void
     {
         $loader = new ArrayLoader(new MenuFactory());
 
         $this->assertSame($expected, $loader->supports($data));
     }
 
-    public function provideSupportingData()
+    public function provideSupportingData(): array
     {
         return [
             [[], true],

--- a/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
@@ -2,20 +2,19 @@
 
 namespace Knp\Menu\Tests\Matcher;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Matcher;
+use Knp\Menu\Matcher\Voter\VoterInterface;
 use PHPUnit\Framework\TestCase;
 
 final class MatcherTest extends TestCase
 {
     /**
-     * @param bool|null $flag
-     * @param bool      $expected
-     *
      * @dataProvider provideItemFlag
      */
-    public function testItemFlag($flag, $expected): void
+    public function testItemFlag(?bool $flag, bool $expected): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('isCurrent')
             ->willReturn($flag);
@@ -25,7 +24,7 @@ final class MatcherTest extends TestCase
         $this->assertSame($expected, $matcher->isCurrent($item));
     }
 
-    public function provideItemFlag()
+    public function provideItemFlag(): array
     {
         return [
             [true, true],
@@ -36,8 +35,8 @@ final class MatcherTest extends TestCase
 
     public function testFlagOverwritesCache(): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $item->expects($this->any())
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $item
             ->method('isCurrent')
             ->will($this->onConsecutiveCalls($this->returnValue(true), $this->returnValue(false)));
 
@@ -48,18 +47,16 @@ final class MatcherTest extends TestCase
     }
 
     /**
-     * @param bool $value
-     *
      * @dataProvider provideBoolean
      */
-    public function testFlagWinsOverVoter($value): void
+    public function testFlagWinsOverVoter(bool $value): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('isCurrent')
             ->willReturn($value);
 
-        $voter = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter = $this->getMockBuilder(VoterInterface::class)->getMock();
         $voter->expects($this->never())
             ->method('matchItem');
 
@@ -69,24 +66,22 @@ final class MatcherTest extends TestCase
     }
 
     /**
-     * @param bool $value
-     *
      * @dataProvider provideBoolean
      */
-    public function testFirstVoterWins($value): void
+    public function testFirstVoterWins(bool $value): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('isCurrent')
             ->willReturn(null);
 
-        $voter1 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter1 = $this->getMockBuilder(VoterInterface::class)->getMock();
         $voter1->expects($this->once())
             ->method('matchItem')
             ->with($this->equalTo($item))
             ->willReturn($value);
 
-        $voter2 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter2 = $this->getMockBuilder(VoterInterface::class)->getMock();
         $voter2->expects($this->never())
             ->method('matchItem');
 
@@ -96,24 +91,22 @@ final class MatcherTest extends TestCase
     }
 
     /**
-     * @param bool $value
-     *
      * @dataProvider provideBoolean
      */
     public function testVoterIterator(bool $value): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('isCurrent')
             ->willReturn(null);
 
-        $voter1 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter1 = $this->getMockBuilder(VoterInterface::class)->getMock();
         $voter1->expects($this->once())
             ->method('matchItem')
             ->with($this->equalTo($item))
             ->willReturn($value);
 
-        $voter2 = $this->getMockBuilder('Knp\Menu\Matcher\Voter\VoterInterface')->getMock();
+        $voter2 = $this->getMockBuilder(VoterInterface::class)->getMock();
         $voter2->expects($this->never())
             ->method('matchItem');
 

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RegexVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RegexVoterTest.php
@@ -2,21 +2,18 @@
 
 namespace Knp\Menu\Tests\Matcher\Voter;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\RegexVoter;
 use PHPUnit\Framework\TestCase;
 
 final class RegexVoterTest extends TestCase
 {
     /**
-     * @param string $exp
-     * @param string $itemUri
-     * @param bool   $expected
-     *
      * @dataProvider provideData
      */
-    public function testMatching($exp, $itemUri, $expected): void
+    public function testMatching(?string $exp, ?string $itemUri, ?bool $expected): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('getUri')
             ->willReturn($itemUri);
@@ -26,7 +23,7 @@ final class RegexVoterTest extends TestCase
         $this->assertSame($expected, $voter->matchItem($item));
     }
 
-    public function provideData()
+    public function provideData(): array
     {
         return [
             'no regexp' => [null, 'foo', null],

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests\Matcher\Voter;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\RouteVoter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -9,20 +10,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class RouteVoterTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!\class_exists('Symfony\Component\HttpFoundation\Request')) {
-            $this->markTestSkipped('The Symfony HttpFoundation component is not available.');
-        }
-    }
-
     public function testMatchingWithoutRequestInStack(): void
     {
-        if (!\class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $this->markTestSkipped('The RequestStack is not available in this version of HttpFoundation.');
-        }
-
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->never())
             ->method('getExtra');
 
@@ -35,7 +25,7 @@ final class RouteVoterTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('getExtra')
             ->with('routes')
@@ -54,16 +44,13 @@ final class RouteVoterTest extends TestCase
     }
 
     /**
-     * @param string       $route
-     * @param array        $parameters
      * @param string|array $itemRoutes
-     * @param bool         $expected
      *
      * @dataProvider provideData
      */
     public function testMatching(?string $route, array $parameters, $itemRoutes, ?bool $expected): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('getExtra')
             ->with('routes')

--- a/tests/Knp/Menu/Tests/Matcher/Voter/UriVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/UriVoterTest.php
@@ -2,21 +2,18 @@
 
 namespace Knp\Menu\Tests\Matcher\Voter;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\UriVoter;
 use PHPUnit\Framework\TestCase;
 
 final class UriVoterTest extends TestCase
 {
     /**
-     * @param string $uri
-     * @param string $itemUri
-     * @param bool   $expected
-     *
      * @dataProvider provideData
      */
-    public function testMatching($uri, $itemUri, $expected): void
+    public function testMatching(?string $uri, ?string $itemUri, ?bool $expected): void
     {
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
         $item->expects($this->any())
             ->method('getUri')
             ->willReturn($itemUri);
@@ -26,7 +23,7 @@ final class UriVoterTest extends TestCase
         $this->assertSame($expected, $voter->matchItem($item));
     }
 
-    public function provideData()
+    public function provideData(): array
     {
         return [
             'no uri' => [null, 'foo', null],

--- a/tests/Knp/Menu/Tests/MenuFactoryTest.php
+++ b/tests/Knp/Menu/Tests/MenuFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Menu\Tests;
 
+use Knp\Menu\Factory\ExtensionInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -11,25 +13,25 @@ final class MenuFactoryTest extends TestCase
     {
         $factory = new MenuFactory();
 
-        $extension1 = $this->getMockBuilder('Knp\Menu\Factory\ExtensionInterface')->getMock();
+        $extension1 = $this->getMockBuilder(ExtensionInterface::class)->getMock();
         $extension1->expects($this->once())
             ->method('buildOptions')
             ->with(['foo' => 'bar'])
             ->willReturn(['uri' => 'foobar']);
         $extension1->expects($this->once())
             ->method('buildItem')
-            ->with($this->isInstanceOf('Knp\Menu\ItemInterface'), $this->containsCustom('foobar'));
+            ->with($this->isInstanceOf(ItemInterface::class), $this->containsCustom('foobar'));
 
         $factory->addExtension($extension1);
 
-        $extension2 = $this->getMockBuilder('Knp\Menu\Factory\ExtensionInterface')->getMock();
+        $extension2 = $this->getMockBuilder(ExtensionInterface::class)->getMock();
         $extension2->expects($this->once())
             ->method('buildOptions')
             ->with(['foo' => 'baz'])
             ->willReturn(['foo' => 'bar']);
         $extension1->expects($this->once())
             ->method('buildItem')
-            ->with($this->isInstanceOf('Knp\Menu\ItemInterface'), $this->containsCustom('foobar'));
+            ->with($this->isInstanceOf(ItemInterface::class), $this->containsCustom('foobar'));
 
         $factory->addExtension($extension2, 10);
 
@@ -48,19 +50,20 @@ final class MenuFactoryTest extends TestCase
             'displayChildren' => false,
         ]);
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $item);
+        $this->assertInstanceOf(ItemInterface::class, $item);
         $this->assertEquals('test', $item->getName());
         $this->assertFalse($item->isDisplayed());
         $this->assertFalse($item->getDisplayChildren());
         $this->assertEquals('foo', $item->getLinkAttribute('class'));
     }
 
-    private function containsCustom($value) {
-        if(method_exists($this, 'contains')) {
+    private function containsCustom(string $value): ?object
+    {
+        if (method_exists($this, 'contains')) {
             return $this->contains($value);
         }
 
-        if(method_exists($this, 'containsEqual')) {
+        if (method_exists($this, 'containsEqual')) {
             return $this->containsEqual($value);
         }
     }

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Menu\Tests;
 
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
 use PHPUnit\Framework\TestCase;
@@ -185,7 +187,7 @@ final class MenuItemGetterSetterTest extends TestCase
 
     public function testSetSameName(): void
     {
-        $parent = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $parent = $this->getMockBuilder(ItemInterface::class)->getMock();
         $parent->expects($this->never())
             ->method('offsetExists');
 
@@ -197,8 +199,8 @@ final class MenuItemGetterSetterTest extends TestCase
 
     public function testFactory(): void
     {
-        $child1 = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $factory = $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock();
+        $child1 = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
         $factory->expects($this->once())
             ->method('createItem')
             ->willReturn($child1);

--- a/tests/Knp/Menu/Tests/MenuItemTreeTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemTreeTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests;
 
+use Knp\Menu\FactoryInterface;
 use Knp\Menu\MenuItem;
 
 final class TestMenuItem extends MenuItem
@@ -51,7 +52,7 @@ final class MenuItemTreeTest extends MenuTestCase
 
     public function testMoveSampleMenuToNewRoot(): void
     {
-        $newRoot = new TestMenuItem('newRoot', $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock());
+        $newRoot = new TestMenuItem('newRoot', $this->getMockBuilder(FactoryInterface::class)->getMock());
         $newRoot->addChild($this->menu);
 
         $this->assertEquals(1, $this->menu->getLevel());
@@ -123,7 +124,7 @@ final class MenuItemTreeTest extends MenuTestCase
         $this->assertNull($this->menu['Fake']);
 
         $this->menu['New Child'] = 'New Label';
-        $this->assertEquals('Knp\Menu\MenuItem', \get_class($this->menu['New Child']));
+        $this->assertEquals(MenuItem::class, \get_class($this->menu['New Child']));
         $this->assertEquals('New Child', $this->menu['New Child']->getName());
         $this->assertEquals('New Label', $this->menu['New Child']->getLabel());
 
@@ -167,7 +168,7 @@ final class MenuItemTreeTest extends MenuTestCase
 
     public function testAddChildDoesNotUSeTheFactoryIfItem(): void
     {
-        $factory = $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock();
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
         $factory->expects($this->never())
             ->method('createItem');
         $menu = new MenuItem('Root li', $factory);
@@ -178,7 +179,7 @@ final class MenuItemTreeTest extends MenuTestCase
     {
         $this->expectException(\LogicException::class);
 
-        $factory = $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock();
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
         $menu = new MenuItem('Root li', $factory);
         $child = new MenuItem('Child 3', $factory);
         $menu->addChild($child);

--- a/tests/Knp/Menu/Tests/Provider/ArrayAccessProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/ArrayAccessProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests\Provider;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\ArrayAccessProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ final class ArrayAccessProviderTest extends TestCase
     public function testGetExistentMenu(): void
     {
         $registry = new \ArrayObject();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $registry['menu'] = $menu;
         $provider = new ArrayAccessProvider($registry, ['default' => 'menu']);
         $this->assertSame($menu, $provider->get('default'));
@@ -27,8 +28,8 @@ final class ArrayAccessProviderTest extends TestCase
     public function testGetMenuAsClosure(): void
     {
         $registry = new \ArrayObject();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $registry['menu'] = function ($options, $c) use ($menu) {
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $registry['menu'] = static function (array $options, object $c) use ($menu) {
             $c['options'] = $options;
 
             return $menu;

--- a/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
@@ -2,14 +2,16 @@
 
 namespace Knp\Menu\Tests\Provider;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\ChainProvider;
+use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ChainProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $innerProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
+        $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $innerProvider->expects($this->at(0))
             ->method('has')
             ->with('first')
@@ -33,8 +35,8 @@ final class ChainProviderTest extends TestCase
 
     public function testGetExistentMenu(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $innerProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $innerProvider->expects($this->any())
             ->method('has')
             ->with('default')
@@ -52,8 +54,8 @@ final class ChainProviderTest extends TestCase
 
     public function testGetWithOptions(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $innerProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $innerProvider->expects($this->any())
             ->method('has')
             ->with('default', ['foo' => 'bar'])
@@ -79,9 +81,9 @@ final class ChainProviderTest extends TestCase
 
     public function testIterator(): void
     {
-        $menu = $this->prophesize('Knp\Menu\ItemInterface');
+        $menu = $this->prophesize(ItemInterface::class);
 
-        $innerProvider = $this->prophesize('Knp\Menu\Provider\MenuProviderInterface');
+        $innerProvider = $this->prophesize(MenuProviderInterface::class);
         $innerProvider->has('foo', [])->willReturn(true);
         $innerProvider->get('foo', [])->willReturn($menu);
 

--- a/tests/Knp/Menu/Tests/Provider/LazyProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/LazyProviderTest.php
@@ -10,7 +10,7 @@ final class LazyProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $provider = new LazyProvider(['first' => function (): void {}, 'second' => function (): void {}]);
+        $provider = new LazyProvider(['first' => static function (): void {}, 'second' => static function (): void {}]);
         $this->assertTrue($provider->has('first'));
         $this->assertTrue($provider->has('second'));
         $this->assertFalse($provider->has('third'));
@@ -18,7 +18,7 @@ final class LazyProviderTest extends TestCase
 
     public function testGetExistentMenu(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $provider = new LazyProvider(['default' => function () use ($menu) {
             return $menu;
         }]);
@@ -27,7 +27,7 @@ final class LazyProviderTest extends TestCase
 
     public function testGetMenuAsClosure(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $provider = new LazyProvider(['default' => [function () use ($menu) {
             return new FakeBuilder($menu);
         }, 'build']]);

--- a/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
@@ -2,14 +2,16 @@
 
 namespace Knp\Menu\Tests\Provider;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\PsrProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 final class PsrProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('first')->willReturn(true);
         $container->has('second')->willReturn(true);
         $container->has('third')->willReturn(false);
@@ -22,9 +24,9 @@ final class PsrProviderTest extends TestCase
 
     public function testGetExistentMenu(): void
     {
-        $menu = $this->prophesize('Knp\Menu\ItemInterface');
+        $menu = $this->prophesize(ItemInterface::class);
 
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('menu')->willReturn(true);
         $container->get('menu')->willReturn($menu);
 
@@ -36,7 +38,7 @@ final class PsrProviderTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('non-existent')->willReturn(false);
 
         $provider = new PsrProvider($container->reveal());

--- a/tests/Knp/Menu/Tests/Renderer/ArrayAccessProviderTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/ArrayAccessProviderTest.php
@@ -3,6 +3,7 @@
 namespace Knp\Menu\Tests\Renderer;
 
 use Knp\Menu\Renderer\ArrayAccessProvider;
+use Knp\Menu\Renderer\RendererInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ArrayAccessProviderTest extends TestCase
@@ -18,7 +19,7 @@ final class ArrayAccessProviderTest extends TestCase
     public function testGetExistentRenderer(): void
     {
         $registry = new \ArrayObject();
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $registry['renderer'] = $renderer;
         $provider = new ArrayAccessProvider($registry, 'default', ['default' => 'renderer']);
         $this->assertSame($renderer, $provider->get('default'));
@@ -27,7 +28,7 @@ final class ArrayAccessProviderTest extends TestCase
     public function testGetDefaultRenderer(): void
     {
         $registry = new \ArrayObject();
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $registry['renderer'] = $renderer;
         $provider = new ArrayAccessProvider($registry, 'default', ['default' => 'renderer']);
         $this->assertSame($renderer, $provider->get());

--- a/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
@@ -3,13 +3,15 @@
 namespace Knp\Menu\Tests\Renderer;
 
 use Knp\Menu\Renderer\PsrProvider;
+use Knp\Menu\Renderer\RendererInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 final class PsrProviderTest extends TestCase
 {
     public function testHas(): void
     {
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('first')->willReturn(true);
         $container->has('second')->willReturn(true);
         $container->has('third')->willReturn(false);
@@ -22,9 +24,9 @@ final class PsrProviderTest extends TestCase
 
     public function testGetExistentRenderer(): void
     {
-        $renderer = $this->prophesize('Knp\Menu\Renderer\RendererInterface');
+        $renderer = $this->prophesize(RendererInterface::class);
 
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('renderer')->willReturn(true);
         $container->get('renderer')->willReturn($renderer);
 
@@ -34,9 +36,9 @@ final class PsrProviderTest extends TestCase
 
     public function testGetDefaultRenderer(): void
     {
-        $renderer = $this->prophesize('Knp\Menu\Renderer\RendererInterface');
+        $renderer = $this->prophesize(RendererInterface::class);
 
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('default')->willReturn(true);
         $container->get('default')->willReturn($renderer);
 
@@ -48,7 +50,7 @@ final class PsrProviderTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $container = $this->prophesize('Psr\Container\ContainerInterface');
+        $container = $this->prophesize(ContainerInterface::class);
         $container->has('non-existent')->willReturn(false);
 
         $provider = new PsrProvider($container->reveal(), 'default');

--- a/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/TwigRendererTest.php
@@ -13,14 +13,10 @@ final class TwigRendererTest extends AbstractRendererTest
 {
     public function createRenderer(MatcherInterface $matcher): TwigRenderer
     {
-        if (!\class_exists(Environment::class)) {
-            $this->markTestSkipped('Twig is not available');
-        }
         $loader = new FilesystemLoader(__DIR__.'/../../../../../src/Knp/Menu/Resources/views');
         $environment = new Environment($loader);
-        $renderer = new TwigRenderer($environment, 'knp_menu.html.twig', $matcher, ['compressed' => true]);
 
-        return $renderer;
+        return new TwigRenderer($environment, 'knp_menu.html.twig', $matcher, ['compressed' => true]);
     }
 
     public function testRenderOrderedList(): void

--- a/tests/Knp/Menu/Tests/Twig/HelperTest.php
+++ b/tests/Knp/Menu/Tests/Twig/HelperTest.php
@@ -2,25 +2,30 @@
 
 namespace Knp\Menu\Tests\Twig;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Matcher;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Knp\Menu\Renderer\RendererInterface;
+use Knp\Menu\Renderer\RendererProviderInterface;
 use Knp\Menu\Twig\Helper;
+use Knp\Menu\Util\MenuManipulator;
 use PHPUnit\Framework\TestCase;
 
 final class HelperTest extends TestCase
 {
     public function testRenderMenu(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $renderer->expects($this->once())
             ->method('render')
             ->with($menu, [])
             ->willReturn('<p>foobar</p>')
         ;
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $rendererProvider->expects($this->once())
             ->method('get')
             ->with(null)
@@ -34,15 +39,15 @@ final class HelperTest extends TestCase
 
     public function testRenderMenuWithOptions(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $renderer->expects($this->once())
             ->method('render')
             ->with($menu, ['firstClass' => 'test'])
             ->willReturn('<p>foobar</p>')
         ;
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $rendererProvider->expects($this->once())
             ->method('get')
             ->with(null)
@@ -56,15 +61,15 @@ final class HelperTest extends TestCase
 
     public function testRenderMenuWithRenderer(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $renderer->expects($this->once())
             ->method('render')
             ->with($menu, [])
             ->willReturn('<p>foobar</p>')
         ;
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $rendererProvider->expects($this->once())
             ->method('get')
             ->with('custom')
@@ -78,22 +83,22 @@ final class HelperTest extends TestCase
 
     public function testRenderMenuByName(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $menuProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $menuProvider->expects($this->once())
             ->method('get')
             ->with('default')
             ->willReturn($menu)
         ;
 
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $renderer->expects($this->once())
             ->method('render')
             ->with($menu, [])
             ->willReturn('<p>foobar</p>')
         ;
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $rendererProvider->expects($this->once())
             ->method('get')
             ->with(null)
@@ -107,9 +112,9 @@ final class HelperTest extends TestCase
 
     public function testGetMenu(): void
     {
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
-        $menuProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
+        $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menuProvider->expects($this->once())
             ->method('get')
             ->with('default')
@@ -125,16 +130,16 @@ final class HelperTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $helper = new Helper($rendererProvider);
         $helper->get('default');
     }
 
     public function testGetMenuWithOptions(): void
     {
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
-        $menuProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
+        $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menuProvider->expects($this->once())
             ->method('get')
             ->with('default', ['foo' => 'bar'])
@@ -148,10 +153,10 @@ final class HelperTest extends TestCase
 
     public function testGetMenuByPath(): void
     {
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
-        $menuProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
-        $child = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
+        $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
+        $child = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menu->expects($this->any())
             ->method('getChild')
             ->with('child')
@@ -172,14 +177,14 @@ final class HelperTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
-        $menuProvider = $this->getMockBuilder('Knp\Menu\Provider\MenuProviderInterface')->getMock();
-        $child = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
+        $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
+        $child = $this->getMockBuilder(ItemInterface::class)->getMock();
         $child->expects($this->any())
             ->method('getChild')
             ->willReturn(null)
         ;
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menu->expects($this->any())
             ->method('getChild')
             ->with('child')
@@ -198,22 +203,22 @@ final class HelperTest extends TestCase
 
     public function testRenderMenuByPath(): void
     {
-        $child = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $child = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menu->expects($this->any())
             ->method('getChild')
             ->with('child')
             ->willReturn($child)
         ;
 
-        $renderer = $this->getMockBuilder('Knp\Menu\Renderer\RendererInterface')->getMock();
+        $renderer = $this->getMockBuilder(RendererInterface::class)->getMock();
         $renderer->expects($this->once())
             ->method('render')
             ->with($child, [])
             ->willReturn('<p>foobar</p>')
         ;
 
-        $rendererProvider = $this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock();
+        $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $rendererProvider->expects($this->once())
             ->method('get')
             ->with(null)
@@ -230,21 +235,21 @@ final class HelperTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The array cannot be empty');
 
-        $helper = new Helper($this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock());
+        $helper = new Helper($this->getMockBuilder(RendererProviderInterface::class)->getMock());
         $helper->render([]);
     }
 
     public function testBreadcrumbsArray(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
 
-        $manipulator = $this->getMockBuilder('Knp\Menu\Util\MenuManipulator')->getMock();
+        $manipulator = $this->getMockBuilder(MenuManipulator::class)->getMock();
         $manipulator->expects($this->any())
             ->method('getBreadcrumbsArray')
             ->with($menu)
             ->willReturn(['A', 'B']);
 
-        $helper = new Helper($this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock(), null, $manipulator);
+        $helper = new Helper($this->getMockBuilder(RendererProviderInterface::class)->getMock(), null, $manipulator);
 
         $this->assertEquals(['A', 'B'], $helper->getBreadcrumbsArray($menu));
     }
@@ -253,7 +258,7 @@ final class HelperTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        $helper = new Helper($this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock());
+        $helper = new Helper($this->getMockBuilder(RendererProviderInterface::class)->getMock());
         $helper->getCurrentItem('default');
     }
 
@@ -271,7 +276,7 @@ final class HelperTest extends TestCase
         $menu['c2']['c2_2']->addChild('c2_2_2')->setCurrent(true);
         $menu['c2']['c2_2']->addChild('c2_2_3');
 
-        $helper = new Helper($this->getMockBuilder('Knp\Menu\Renderer\RendererProviderInterface')->getMock(), null, null, $matcher);
+        $helper = new Helper($this->getMockBuilder(RendererProviderInterface::class)->getMock(), null, null, $matcher);
 
         $this->assertSame('c2_2_2', $helper->getCurrentItem($menu)->getName());
     }

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests\Twig;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Twig\Helper;
 use Knp\Menu\Twig\MenuExtension;
@@ -13,16 +14,9 @@ use Twig\TemplateWrapper;
 
 final class MenuExtensionTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!\class_exists(Environment::class)) {
-            $this->markTestSkipped('Twig is not available');
-        }
-    }
-
     public function testRenderMenu(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['render']);
         $helper->expects($this->once())
             ->method('render')
@@ -35,7 +29,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testRenderMenuWithOptions(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['render']);
         $helper->expects($this->once())
             ->method('render')
@@ -48,7 +42,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testRenderMenuWithRenderer(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['render']);
         $helper->expects($this->once())
             ->method('render')
@@ -73,7 +67,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testRetrieveMenuByName(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['get', 'render']);
         $helper->expects($this->once())
             ->method('render')
@@ -103,7 +97,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testPathAsString(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['get']);
         $manipulator = $this->getManipulatorMock(['getPathAsString']);
         $helper->expects($this->any())
@@ -121,7 +115,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testIsCurrent(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock([]);
         $matcher = $this->getMatcherMock();
         $matcher->expects($this->any())
@@ -135,7 +129,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testIsAncestor(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock([]);
         $matcher = $this->getMatcherMock();
         $matcher->expects($this->any())
@@ -149,7 +143,7 @@ final class MenuExtensionTest extends TestCase
 
     public function testGetCurrentItem(): void
     {
-        $menu = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['get', 'getCurrentItem']);
         $helper->expects($this->once())
             ->method('get')
@@ -168,7 +162,7 @@ final class MenuExtensionTest extends TestCase
 
     private function getHelperMock(array $methods)
     {
-        return $this->getMockBuilder('Knp\Menu\Twig\Helper')
+        return $this->getMockBuilder(Helper::class)
             ->disableOriginalConstructor()
             ->setMethods($methods)
             ->getMock()
@@ -177,7 +171,7 @@ final class MenuExtensionTest extends TestCase
 
     private function getManipulatorMock(array $methods)
     {
-        return $this->getMockBuilder('Knp\Menu\Util\MenuManipulator')
+        return $this->getMockBuilder(MenuManipulator::class)
             ->disableOriginalConstructor()
             ->setMethods($methods)
             ->getMock()
@@ -186,7 +180,7 @@ final class MenuExtensionTest extends TestCase
 
     private function getMatcherMock()
     {
-        return $this->getMockBuilder('Knp\Menu\Matcher\MatcherInterface')->getMock();
+        return $this->getMockBuilder(MatcherInterface::class)->getMock();
     }
 
     private function getTemplate(

--- a/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
+++ b/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Menu\Tests\Util;
 
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\MenuItem;
 use Knp\Menu\Tests\MenuTestCase;
@@ -49,9 +50,12 @@ final class MenuManipulatorTest extends MenuTestCase
     }
 
     /**
+     * @param int|string      $offset
+     * @param int|string|null $length
+     *
      * @dataProvider getSliceData
      */
-    public function testSlice($offset, $length, $count, $keys): void
+    public function testSlice($offset, $length, int $count, array $keys): void
     {
         $manipulator = new MenuManipulator();
         $sliced = $manipulator->slice($this->pt1, $offset, $length);
@@ -59,7 +63,7 @@ final class MenuManipulatorTest extends MenuTestCase
         $this->assertEquals($keys, \array_keys($sliced->getChildren()));
     }
 
-    public function getSliceData()
+    public function getSliceData(): array
     {
         $this->setUp();
 
@@ -74,20 +78,22 @@ final class MenuManipulatorTest extends MenuTestCase
     }
 
     /**
+     * @param int|string $length
+     *
      * @dataProvider getSplitData
      */
-    public function testSplit($length, $count, $keys): void
+    public function testSplit($length, int $count, array $keys): void
     {
         $manipulator = new MenuManipulator();
-        $splitted = $manipulator->split($this->pt1, $length);
-        $this->assertArrayHasKey('primary', $splitted);
-        $this->assertArrayHasKey('secondary', $splitted);
-        $this->assertCount($count, $splitted['primary']);
-        $this->assertCount(3 - $count, $splitted['secondary']);
-        $this->assertEquals($keys, \array_keys($splitted['primary']->getChildren()));
+        $split = $manipulator->split($this->pt1, $length);
+        $this->assertArrayHasKey('primary', $split);
+        $this->assertArrayHasKey('secondary', $split);
+        $this->assertCount($count, $split['primary']);
+        $this->assertCount(3 - $count, $split['secondary']);
+        $this->assertEquals($keys, \array_keys($split['primary']->getChildren()));
     }
 
-    public function getSplitData()
+    public function getSplitData(): array
     {
         $this->setUp();
 
@@ -128,13 +134,9 @@ final class MenuManipulatorTest extends MenuTestCase
             $manipulator->getBreadcrumbsArray($this->menu['child'], 'subitem1')
         );
 
-        $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
-        $item->expects($this->any())
-            ->method('getLabel')
-            ->willReturn('mock');
-        $item->expects($this->any())
-            ->method('getUri')
-            ->willReturn('foo');
+        $item = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $item->method('getLabel')->willReturn('mock');
+        $item->method('getUri')->willReturn('foo');
 
         $this->assertEquals(
             [
@@ -185,7 +187,7 @@ final class MenuManipulatorTest extends MenuTestCase
         $menu = $factory->createItem('test_menu');
 
         foreach (\range(1, 2) as $i) {
-            $child = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
+            $child = $this->getMockBuilder(ItemInterface::class)->getMock();
             $child->expects($this->any())
                 ->method('getName')
                 ->willReturn('Child '.$i)
@@ -368,15 +370,9 @@ final class MenuManipulatorTest extends MenuTestCase
     }
 
     /**
-     * Create a new MenuItem
-     *
-     * @param string $name
-     * @param string $uri
-     * @param array  $attributes
-     *
-     * @return MenuItem
+     * Create a new MenuItem.
      */
-    private function createMenu(string $name = 'test_menu', string $uri = 'homepage', array $attributes = []): MenuItem
+    private function createMenu(string $name = 'test_menu', string $uri = 'homepage', array $attributes = []): ItemInterface
     {
         $factory = new MenuFactory();
 


### PR DESCRIPTION
* remove useless checks for libraries
* enforce argument types and return types
* apply `::class` constant where relevant