### PR TITLE
ensure forward-compatibility with Symfony 6

### DIFF
--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -23,7 +23,7 @@ class RouteVoter implements VoterInterface
 
     public function matchItem(ItemInterface $item): ?bool
     {
-        if (\is_callable([$this->requestStack, 'mainRequest'])) {
+        if (\is_callable([$this->requestStack, 'getMainRequest'])) {
             $request = $this->requestStack->getMainRequest();   // symfony 5.3+
         } else {
             $request = $this->requestStack->getMasterRequest();

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -23,7 +23,11 @@ class RouteVoter implements VoterInterface
 
     public function matchItem(ItemInterface $item): ?bool
     {
-        $request = $this->requestStack->getMasterRequest();
+        if (\is_callable([$this->requestStack, 'mainRequest'])) {
+            $request = $this->requestStack->getMainRequest();   // symfony 5.3+
+        } else {
+            $request = $this->requestStack->getMasterRequest();
+        }
 
         if (null === $request) {
             return null;


### PR DESCRIPTION
This should fix tests for current dev (Symfony 5.3, where using `getMasterRequest` is deprecated)