### PR TITLE
Fix array access annotation.

### DIFF
--- a/src/Knp/Menu/ItemInterface.php
+++ b/src/Knp/Menu/ItemInterface.php
@@ -9,7 +9,7 @@ namespace Knp\Menu;
  * most of the time by default.
  * Originally taken from ioMenuPlugin (http://github.com/weaverryan/ioMenuPlugin)
  *
- * @extends \ArrayAccess<string, self|string>
+ * @extends \ArrayAccess<string, self|null>
  * @extends \IteratorAggregate<string, self>
  */
 interface ItemInterface extends \ArrayAccess, \Countable, \IteratorAggregate


### PR DESCRIPTION
The `string` annotation made [my phpstan checks blew up](https://github.com/icings/menu/pull/25/checks?check_run_id=2700419729) for usages like `$item['Child']->addItem()`.

Children cannot be strings, the implementation returns `ItemInterface|null`.