### PR TITLE
Fix deprecation of PHPUnit\Framework\TestCase::prophesize()

### DIFF
--- a/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
@@ -6,9 +6,12 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\ChainProvider;
 use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class ChainProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testHas(): void
     {
         $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();

--- a/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/PsrProviderTest.php
@@ -5,10 +5,13 @@ namespace Knp\Menu\Tests\Provider;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\PsrProvider;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 final class PsrProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testHas(): void
     {
         $container = $this->prophesize(ContainerInterface::class);

--- a/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/PsrProviderTest.php
@@ -5,10 +5,13 @@ namespace Knp\Menu\Tests\Renderer;
 use Knp\Menu\Renderer\PsrProvider;
 use Knp\Menu\Renderer\RendererInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 final class PsrProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testHas(): void
     {
         $container = $this->prophesize(ContainerInterface::class);


### PR DESCRIPTION
 Fix warnings running:
 
`$ phpunit tests`

 For future PHPUnit 10

Still remains:

1) Knp\Menu\Tests\Provider\ChainProviderTest::testHas
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.

But I try to change at() by exactly() and it is not working. So at least removing all warnings less one

