### PR TITLE
setChildren properly sets the parent on children

### DIFF
--- a/src/Knp/Menu/MenuItem.php
+++ b/src/Knp/Menu/MenuItem.php
@@ -330,7 +330,7 @@ class MenuItem implements ItemInterface
     {
         if (!$child instanceof ItemInterface) {
             $child = $this->factory->createItem($child, $options);
-        } elseif (null !== $child->getParent()) {
+        } elseif (null !== $child->getParent() && $this !== $child->getParent()) {
             throw new \InvalidArgumentException('Cannot add menu item as child, it already belongs to another menu (e.g. has a parent).');
         }
 
@@ -423,7 +423,8 @@ class MenuItem implements ItemInterface
 
     public function setChildren(array $children): ItemInterface
     {
-        $this->children = $children;
+        $this->children = [];
+        array_map([$this, 'addChild'], $children);
 
         return $this;
     }

--- a/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
+++ b/tests/Knp/Menu/Tests/MenuItemGetterSetterTest.php
@@ -172,7 +172,7 @@ final class MenuItemGetterSetterTest extends TestCase
         $menu = $this->createMenu();
         $child = $this->createMenu('child_menu');
         $menu->setChildren([$child]);
-        $this->assertEquals([$child], $menu->getChildren());
+        $this->assertEquals(['child_menu' => $child], $menu->getChildren());
     }
 
     public function testSetExistingNameThrowsAnException(): void

--- a/tests/Knp/Menu/Tests/MenuTestCase.php
+++ b/tests/Knp/Menu/Tests/MenuTestCase.php
@@ -63,7 +63,8 @@ abstract class MenuTestCase extends TestCase
 
         $this->pt2 = $this->menu->addChild('Parent 2');
         $this->ch4 = $this->pt2->addChild('Child 4');
-        $this->gc1 = $this->ch4->addChild('Grandchild 1');
+        $this->gc1 = new MenuItem('Grandchild 1', $factory);
+        $this->ch4->setChildren([$this->gc1]);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Children items sets by `\Knp\Menu\MenuItem::setChildren` setter does not have parent properly set.
This issue does not occur in `\Knp\Menu\MenuItem::addChild`.
