### PR TITLE
Add support for query parameters matching to RouteVoter

### DIFF
--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -58,7 +58,7 @@ class RouteVoter implements VoterInterface
     }
 
     /**
-     * @phpstan-param array{route?: string|null, pattern?: string|null, parameters?: array<string, mixed>} $testedRoute
+     * @phpstan-param array{route?: string|null, pattern?: string|null, parameters?: array<string, mixed>, query_parameters?: array<string, string>} $testedRoute
      */
     private function isMatchingRoute(Request $request, array $testedRoute): bool
     {
@@ -76,6 +76,14 @@ class RouteVoter implements VoterInterface
             throw new \InvalidArgumentException('Routes extra items must have a "route" or "pattern" key.');
         }
 
+        return $this->isMatchingParameters($request, $testedRoute) && $this->isMatchingQueryParameters($request, $testedRoute);
+    }
+
+    /**
+     * @phpstan-param array{route?: string|null, pattern?: string|null, parameters?: array<string, mixed>, query_parameters?: array<string, string>} $testedRoute
+     */
+    private function isMatchingParameters(Request $request, array $testedRoute): bool
+    {
         if (!isset($testedRoute['parameters'])) {
             return true;
         }
@@ -85,6 +93,27 @@ class RouteVoter implements VoterInterface
         foreach ($testedRoute['parameters'] as $name => $value) {
             // cast both to string so that we handle integer and other non-string parameters, but don't stumble on 0 == 'abc'.
             if (!isset($routeParameters[$name]) || (string) $routeParameters[$name] !== (string) $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @phpstan-param array{route?: string|null, pattern?: string|null, parameters?: array<string, mixed>, query_parameters?: array<string, string>} $testedRoute
+     */
+    private function isMatchingQueryParameters(Request $request, array $testedRoute): bool
+    {
+        if (!isset($testedRoute['query_parameters'])) {
+            return true;
+        }
+
+        $routeQueryParameters = $request->query->all();
+
+        foreach ($testedRoute['query_parameters'] as $name => $value) {
+            // cast both to string so that we handle integer and other non-string parameters, but don't stumble on 0 == 'abc'.
+            if (!isset($routeQueryParameters[$name]) || is_array($routeQueryParameters[$name]) || (string) $routeQueryParameters[$name] !== (string) $value) {
                 return false;
             }
         }


### PR DESCRIPTION
For case where query parameters are used to generate different pages.

For exemple:

- /tasks?state=open
- /tasks?state=done
- /tasks?state=archived
- ...