### PR TITLE
Fix phpstan issue

### DIFF
--- a/src/Knp/Menu/Iterator/RecursiveItemIterator.php
+++ b/src/Knp/Menu/Iterator/RecursiveItemIterator.php
@@ -11,7 +11,7 @@ namespace Knp\Menu\Iterator;
 class RecursiveItemIterator extends \IteratorIterator implements \RecursiveIterator
 {
     /**
-     * @param \Traversable<string, \Knp\Menu\ItemInterface> $iterator
+     * @param \Traversable<string|int, \Knp\Menu\ItemInterface> $iterator
      */
     final public function __construct(\Traversable $iterator)
     {


### PR DESCRIPTION
Currently when creating a RecursiveItemIterator passing a new ArrayIterator, the Iterator is indexed by int.

```php
$treeIterator = new \RecursiveIteratorIterator(
            new RecursiveItemIterator(
                new \ArrayIterator(array($menu))
            ), \RecursiveIteratorIterator::SELF_FIRST
        );
```

So we got the following error:
```
Parameter #1 $iterator of class Knp\Menu\Iterator\RecursiveItemIterator constructor expects
Traversable<string, Knp\Menu\ItemInterface>, ArrayIterator<int, Knp\Menu\ItemInterface> given.
```
I can notice that the typehint in CurrentItemFilterIterator is ok:
https://github.com/KnpLabs/KnpMenu/blob/master/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php