### PR TITLE
feat: drop support of php 7.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,12 +42,6 @@ jobs:
                     - description: 'Symfony 5.4'
                       php: '8.0'
                       symfony: 5.4.*
-                    - description: 'Symfony 5.4'
-                      php: '8.1'
-                      symfony: 5.4.*
-                    - description: 'Symfony 5.4'
-                      php: '8.2'
-                      symfony: 5.4.*
                     - description: 'Dev deps'
                       php: '8.2'
                       dev: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,15 +42,12 @@ jobs:
                     - description: 'Symfony 5.4'
                       php: '8.0'
                       symfony: 5.4.*
-                    - description: 'Symfony 6.0'
-                      php: '8.0'
-                      symfony: 6.0.*
-                    - description: 'Symfony 6.1'
+                    - description: 'Symfony 5.4'
                       php: '8.1'
-                      symfony: 6.1.*
-                    - description: 'Symfony 6.2'
+                      symfony: 5.4.*
+                    - description: 'Symfony 5.4'
                       php: '8.2'
-                      symfony: 6.2.*
+                      symfony: 5.4.*
                     - description: 'Dev deps'
                       php: '8.2'
                       dev: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     check:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -15,7 +15,7 @@ jobs:
             - name: Validate composer.json
               run: composer validate --strict --no-check-lock
     cs-fixer:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         name: PHP-CS-Fixer
         steps:
             - name: Checkout
@@ -23,7 +23,7 @@ jobs:
             - name: Fix CS
               uses: docker://oskarstark/php-cs-fixer-ga
     tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:
@@ -39,17 +39,20 @@ jobs:
                       composer_option: '--prefer-lowest'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: max[self]=0
-                    - description: 'Symfony 4.4'
-                      php: '8.0'
-                      symfony: 4.4.*
                     - description: 'Symfony 5.4'
                       php: '8.0'
                       symfony: 5.4.*
                     - description: 'Symfony 6.0'
                       php: '8.0'
                       symfony: 6.0.*
-                    - description: 'Dev deps'
+                    - description: 'Symfony 6.1'
                       php: '8.1'
+                      symfony: 6.1.*
+                    - description: 'Symfony 6.2'
+                      php: '8.2'
+                      symfony: 6.2.*
+                    - description: 'Dev deps'
+                      php: '8.2'
                       dev: true
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:
@@ -72,7 +75,7 @@ jobs:
             - run: composer update --no-interaction --no-progress --ansi ${{ matrix.composer_option }}
             - run: vendor/bin/phpunit
     phpstan:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         name: PHPStan
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,23 +29,21 @@ jobs:
             matrix:
                 include:
                     - description: 'No Symfony specified'
-                      php: '7.4'
-                    - description: 'No Symfony specified'
                       php: '8.0'
                     - description: 'No Symfony specified'
                       php: '8.1'
                     - description: 'No Symfony specified'
                       php: '8.2'
                     - description: 'Lowest deps'
-                      php: '7.4'
+                      php: '8.0'
                       composer_option: '--prefer-lowest'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: max[self]=0
                     - description: 'Symfony 4.4'
-                      php: '7.4'
+                      php: '8.0'
                       symfony: 4.4.*
                     - description: 'Symfony 5.4'
-                      php: '7.4'
+                      php: '8.0'
                       symfony: 5.4.*
                     - description: 'Symfony 6.0'
                       php: '8.0'

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,8 +10,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP80Migration:risky' => true,
+        '@PHPUnit84Migration:risky' => true,
         'ordered_imports' => true,
         'declare_strict_types' => false,
         'native_function_invocation' => ['include' => ['@internal']],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.4 (2023-xx-xx)
 
-* Removed support for unsupported Php version 7.4
+* Removed support for unsupported PHP version 7.4
 
 ## 3.2 (2021-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4 (2023-xx-xx)
+
+* Removed support for unsupported Php version 7.4
+
 ## 3.2 (2021-05-28)
 
 * Remove Symfony 6 deprecations

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.0"
     },
     "conflict": {
         "twig/twig": "<1.42.3 || >=2,<2.9"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.6",
         "psr/container": "^1.0",
         "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^6.1",
+        "symfony/phpunit-bridge": "^6.2",
         "symfony/routing": "^4.4 || ^5.0 || ^6.0",
         "twig/twig": "^1.42.3 || ^2.9 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.6",
         "psr/container": "^1.0",
-        "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.2",
-        "symfony/routing": "^4.4 || ^5.0 || ^6.0",
-        "twig/twig": "^1.42.3 || ^2.9 || ^3.0"
+        "symfony/routing": "^5.4 || ^6.0",
+        "twig/twig": "^2.9 || ^3.0"
     },
     "suggest": {
         "twig/twig": "for the TwigRenderer and the integration with your templates"

--- a/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
+++ b/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
@@ -11,11 +11,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class RoutingExtension implements ExtensionInterface
 {
-    private UrlGeneratorInterface $generator;
-
-    public function __construct(UrlGeneratorInterface $generator)
+    public function __construct(private UrlGeneratorInterface $generator)
     {
-        $this->generator = $generator;
     }
 
     public function buildOptions(array $options = []): array

--- a/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
+++ b/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
@@ -9,14 +9,11 @@ use Knp\Menu\Matcher\MatcherInterface;
  */
 class CurrentItemFilterIterator extends \FilterIterator
 {
-    private MatcherInterface $matcher;
-
     /**
      * @param \Iterator<string|int, \Knp\Menu\ItemInterface> $iterator
      */
-    public function __construct(\Iterator $iterator, MatcherInterface $matcher)
+    public function __construct(\Iterator $iterator, private MatcherInterface $matcher)
     {
-        $this->matcher = $matcher;
 
         parent::__construct($iterator);
     }

--- a/src/Knp/Menu/Iterator/RecursiveItemIterator.php
+++ b/src/Knp/Menu/Iterator/RecursiveItemIterator.php
@@ -6,6 +6,7 @@ namespace Knp\Menu\Iterator;
  * Recursive iterator iterating on an item
  *
  * @extends \IteratorIterator<string, \Knp\Menu\ItemInterface, \Traversable<string, \Knp\Menu\ItemInterface>>
+ *
  * @implements \RecursiveIterator<string, \Knp\Menu\ItemInterface>>
  */
 class RecursiveItemIterator extends \IteratorIterator implements \RecursiveIterator

--- a/src/Knp/Menu/Loader/ArrayLoader.php
+++ b/src/Knp/Menu/Loader/ArrayLoader.php
@@ -12,11 +12,8 @@ use Knp\Menu\ItemInterface;
  */
 class ArrayLoader implements LoaderInterface
 {
-    private FactoryInterface $factory;
-
-    public function __construct(FactoryInterface $factory)
+    public function __construct(private FactoryInterface $factory)
     {
-        $this->factory = $factory;
     }
 
     public function load($data): ItemInterface

--- a/src/Knp/Menu/Loader/ArrayLoader.php
+++ b/src/Knp/Menu/Loader/ArrayLoader.php
@@ -22,7 +22,7 @@ class ArrayLoader implements LoaderInterface
     public function load($data): ItemInterface
     {
         if (!$this->supports($data)) {
-            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected an array but got %s', \is_object($data) ? \get_class($data) : \gettype($data)));
+            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected an array but got %s', \get_debug_type($data)));
         }
 
         return $this->fromArray($data);

--- a/src/Knp/Menu/Loader/NodeLoader.php
+++ b/src/Knp/Menu/Loader/NodeLoader.php
@@ -8,17 +8,14 @@ use Knp\Menu\NodeInterface;
 
 class NodeLoader implements LoaderInterface
 {
-    private FactoryInterface $factory;
-
-    public function __construct(FactoryInterface $factory)
+    public function __construct(private FactoryInterface $factory)
     {
-        $this->factory = $factory;
     }
 
     public function load($data): ItemInterface
     {
         if (!$data instanceof NodeInterface) {
-            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected Knp\Menu\NodeInterface but got %s', \is_object($data) ? \get_class($data) : \gettype($data)));
+            throw new \InvalidArgumentException(\sprintf('Unsupported data. Expected Knp\Menu\NodeInterface but got %s', \get_debug_type($data)));
         }
 
         $item = $this->factory->createItem($data->getName(), $data->getOptions());

--- a/src/Knp/Menu/Matcher/Voter/RegexVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RegexVoter.php
@@ -10,11 +10,8 @@ use Knp\Menu\ItemInterface;
  */
 class RegexVoter implements VoterInterface
 {
-    private ?string $regexp;
-
-    public function __construct(?string $regexp)
+    public function __construct(private ?string $regexp)
     {
-        $this->regexp = $regexp;
     }
 
     public function matchItem(ItemInterface $item): ?bool

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -107,7 +107,7 @@ class RouteVoter implements VoterInterface
 
         foreach ($testedRoute['query_parameters'] as $name => $value) {
             // cast both to string so that we handle integer and other non-string parameters, but don't stumble on 0 == 'abc'.
-            if (!isset($routeQueryParameters[$name]) || is_array($routeQueryParameters[$name]) || (string) $routeQueryParameters[$name] !== (string) $value) {
+            if (!isset($routeQueryParameters[$name]) || \is_array($routeQueryParameters[$name]) || (string) $routeQueryParameters[$name] !== (string) $value) {
                 return false;
             }
         }

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -11,11 +11,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RouteVoter implements VoterInterface
 {
-    private RequestStack $requestStack;
-
-    public function __construct(RequestStack $requestStack)
+    public function __construct(private RequestStack $requestStack)
     {
-        $this->requestStack = $requestStack;
     }
 
     public function matchItem(ItemInterface $item): ?bool

--- a/src/Knp/Menu/Matcher/Voter/UriVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/UriVoter.php
@@ -9,11 +9,8 @@ use Knp\Menu\ItemInterface;
  */
 class UriVoter implements VoterInterface
 {
-    private ?string $uri;
-
-    public function __construct(?string $uri = null)
+    public function __construct(private ?string $uri = null)
     {
-        $this->uri = $uri;
     }
 
     public function matchItem(ItemInterface $item): ?bool

--- a/src/Knp/Menu/Provider/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Provider/ArrayAccessProvider.php
@@ -14,23 +14,11 @@ use Knp\Menu\ItemInterface;
 class ArrayAccessProvider implements MenuProviderInterface
 {
     /**
-     * @var \ArrayAccess<string, ItemInterface|callable>
-     */
-    private \ArrayAccess $registry;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $menuIds;
-
-    /**
      * @param \ArrayAccess<string, ItemInterface|callable> $registry
      * @param array<string, string>                        $menuIds  The map between menu identifiers and registry keys
      */
-    public function __construct(\ArrayAccess $registry, array $menuIds = [])
+    public function __construct(private \ArrayAccess $registry, private array $menuIds = [])
     {
-        $this->registry = $registry;
-        $this->menuIds = $menuIds;
     }
 
     public function get(string $name, array $options = []): ItemInterface

--- a/src/Knp/Menu/Provider/LazyProvider.php
+++ b/src/Knp/Menu/Provider/LazyProvider.php
@@ -14,16 +14,10 @@ use Knp\Menu\ItemInterface;
 class LazyProvider implements MenuProviderInterface
 {
     /**
-     * @var array<string, mixed>
-     */
-    private array $builders;
-
-    /**
      * @phpstan-param array<string, callable|array{\Closure, string}> $builders
      */
-    public function __construct(array $builders)
+    public function __construct(private array $builders)
     {
-        $this->builders = $builders;
     }
 
     public function get(string $name, array $options = []): ItemInterface

--- a/src/Knp/Menu/Provider/PsrProvider.php
+++ b/src/Knp/Menu/Provider/PsrProvider.php
@@ -13,11 +13,8 @@ use Psr\Container\ContainerInterface;
  */
 class PsrProvider implements MenuProviderInterface
 {
-    private ContainerInterface $container;
-
-    public function __construct(ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
-        $this->container = $container;
     }
 
     public function get(string $name, array $options = []): ItemInterface

--- a/src/Knp/Menu/Renderer/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Renderer/ArrayAccessProvider.php
@@ -8,27 +8,12 @@ namespace Knp\Menu\Renderer;
 class ArrayAccessProvider implements RendererProviderInterface
 {
     /**
-     * @var \ArrayAccess<string, RendererInterface>
-     */
-    private \ArrayAccess $registry;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $rendererIds;
-
-    private string $defaultRenderer;
-
-    /**
      * @param \ArrayAccess<string, RendererInterface> $registry
      * @param string                                  $defaultRenderer The name of the renderer used by default
      * @param array<string, string>                   $rendererIds     The map between renderer names and registry keys
      */
-    public function __construct(\ArrayAccess $registry, string $defaultRenderer, array $rendererIds)
+    public function __construct(private \ArrayAccess $registry, private string $defaultRenderer, private array $rendererIds)
     {
-        $this->registry = $registry;
-        $this->rendererIds = $rendererIds;
-        $this->defaultRenderer = $defaultRenderer;
     }
 
     public function get(?string $name = null): RendererInterface

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -11,21 +11,10 @@ use Knp\Menu\Matcher\MatcherInterface;
 class ListRenderer extends Renderer implements RendererInterface
 {
     /**
-     * @var MatcherInterface
-     */
-    protected $matcher;
-
-    /**
-     * @var array<string, mixed>
-     */
-    protected $defaultOptions;
-
-    /**
      * @param array<string, mixed> $defaultOptions
      */
-    public function __construct(MatcherInterface $matcher, array $defaultOptions = [], ?string $charset = null)
+    public function __construct(protected MatcherInterface $matcher, protected array $defaultOptions = [], ?string $charset = null)
     {
-        $this->matcher = $matcher;
         $this->defaultOptions = \array_merge([
             'depth' => null,
             'matchingDepth' => null,

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -147,7 +147,7 @@ class ListRenderer extends Renderer implements RendererInterface
         $html = $this->format('<li'.$this->renderHtmlAttributes($attributes).'>', 'li', $item->getLevel(), $options);
 
         // render the text/link inside the li tag
-        //$html .= $this->format($item->getUri() ? $item->renderLink() : $item->renderLabel(), 'link', $item->getLevel());
+        // $html .= $this->format($item->getUri() ? $item->renderLink() : $item->renderLabel(), 'link', $item->getLevel());
         $html .= $this->renderLink($item, $options);
 
         // renders the embedded ul

--- a/src/Knp/Menu/Renderer/PsrProvider.php
+++ b/src/Knp/Menu/Renderer/PsrProvider.php
@@ -12,17 +12,11 @@ use Psr\Container\ContainerInterface;
  */
 class PsrProvider implements RendererProviderInterface
 {
-    private ContainerInterface $container;
-
-    private string $defaultRenderer;
-
     /**
      * @param string $defaultRenderer id of the default renderer (it should exist in the container to avoid weird failures)
      */
-    public function __construct(ContainerInterface $container, string $defaultRenderer)
+    public function __construct(private ContainerInterface $container, private string $defaultRenderer)
     {
-        $this->container = $container;
-        $this->defaultRenderer = $defaultRenderer;
     }
 
     public function get(?string $name = null): RendererInterface

--- a/src/Knp/Menu/Renderer/Renderer.php
+++ b/src/Knp/Menu/Renderer/Renderer.php
@@ -4,10 +4,7 @@ namespace Knp\Menu\Renderer;
 
 abstract class Renderer
 {
-    /**
-     * @var string
-     */
-    protected $charset = 'UTF-8';
+    protected string $charset = 'UTF-8';
 
     public function __construct(?string $charset = null)
     {

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -8,26 +8,15 @@ use Twig\Environment;
 
 class TwigRenderer implements RendererInterface
 {
-    private Environment $environment;
-
-    private MatcherInterface $matcher;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private array $defaultOptions;
-
     /**
      * @param array<string, mixed> $defaultOptions
      */
     public function __construct(
-        Environment $environment,
-        string $template,
-        MatcherInterface $matcher,
-        array $defaultOptions = []
+        private Environment      $environment,
+        string                   $template,
+        private MatcherInterface $matcher,
+        private array            $defaultOptions = []
     ) {
-        $this->environment = $environment;
-        $this->matcher = $matcher;
         $this->defaultOptions = \array_merge([
             'depth' => null,
             'matchingDepth' => null,

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -12,10 +12,10 @@ class TwigRenderer implements RendererInterface
      * @param array<string, mixed> $defaultOptions
      */
     public function __construct(
-        private Environment      $environment,
-        string                   $template,
+        private Environment $environment,
+        string $template,
         private MatcherInterface $matcher,
-        private array            $defaultOptions = []
+        private array $defaultOptions = []
     ) {
         $this->defaultOptions = \array_merge([
             'depth' => null,

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -15,8 +15,8 @@ class Helper
 {
     public function __construct(
         private RendererProviderInterface $rendererProvider,
-        private ?MenuProviderInterface    $menuProvider = null,
-        private ?MenuManipulator          $menuManipulator = null,
+        private ?MenuProviderInterface $menuProvider = null,
+        private ?MenuManipulator $menuManipulator = null,
         private ?MatcherInterface $matcher = null
     ) {
     }

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -13,24 +13,12 @@ use Knp\Menu\Util\MenuManipulator;
  */
 class Helper
 {
-    private RendererProviderInterface $rendererProvider;
-
-    private ?MenuProviderInterface $menuProvider;
-
-    private ?MenuManipulator $menuManipulator;
-
-    private ?MatcherInterface $matcher;
-
     public function __construct(
-        RendererProviderInterface $rendererProvider,
-        ?MenuProviderInterface $menuProvider = null,
-        ?MenuManipulator $menuManipulator = null,
-        ?MatcherInterface $matcher = null
+        private RendererProviderInterface $rendererProvider,
+        private ?MenuProviderInterface    $menuProvider = null,
+        private ?MenuManipulator          $menuManipulator = null,
+        private ?MatcherInterface $matcher = null
     ) {
-        $this->rendererProvider = $rendererProvider;
-        $this->menuProvider = $menuProvider;
-        $this->menuManipulator = $menuManipulator;
-        $this->matcher = $matcher;
     }
 
     /**

--- a/src/Knp/Menu/Twig/Helper.php
+++ b/src/Knp/Menu/Twig/Helper.php
@@ -94,9 +94,11 @@ class Helper
      *
      * @param mixed $menu
      * @param mixed $subItem A string or array to append onto the end of the array
+     *
      * @phpstan-param string|ItemInterface|array<int|string, string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface>|\Traversable<string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface> $subItem
      *
      * @return array<int, array<string, mixed>>
+     *
      * @phpstan-return list<array{label: string, uri: string|null, item: ItemInterface|null}>
      */
     public function getBreadcrumbsArray($menu, $subItem = null): array

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -78,6 +78,7 @@ class MenuExtension extends AbstractExtension
      *
      * @param ItemInterface|string|array<ItemInterface|string> $menu
      * @param string|array<string|null>|null                   $subItem
+     *
      * @phpstan-param string|ItemInterface|array<int|string, string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface>|\Traversable<string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface> $subItem
      *
      * @return array<int, array<string, mixed>>

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -12,17 +12,8 @@ use Twig\TwigTest;
 
 class MenuExtension extends AbstractExtension
 {
-    private Helper $helper;
-
-    private ?MatcherInterface $matcher;
-
-    private ?MenuManipulator $menuManipulator;
-
-    public function __construct(Helper $helper, ?MatcherInterface $matcher = null, ?MenuManipulator $menuManipulator = null)
+    public function __construct(private Helper $helper, private ?MatcherInterface $matcher = null, private ?MenuManipulator $menuManipulator = null)
     {
-        $this->helper = $helper;
-        $this->matcher = $matcher;
-        $this->menuManipulator = $menuManipulator;
     }
 
     /**

--- a/src/Knp/Menu/Util/MenuManipulator.php
+++ b/src/Knp/Menu/Util/MenuManipulator.php
@@ -207,6 +207,7 @@ class MenuManipulator
      *   * [['label' => 'subItem1', 'url' => '@homepage'], ['label' => 'subItem2']]
      *
      * @param string|ItemInterface|array<int|string, mixed>|\Traversable<mixed> $subItem A string or array to append onto the end of the array
+     *
      * @phpstan-param string|ItemInterface|array<int|string, string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface>|\Traversable<string|int|float|null|array{label: string, url: string|null, item: ItemInterface|null}|ItemInterface> $subItem
      *
      * @return array<int, array<string, mixed>>

--- a/tests/Knp/Menu/Tests/Loader/ArrayLoaderTest.php
+++ b/tests/Knp/Menu/Tests/Loader/ArrayLoaderTest.php
@@ -84,11 +84,9 @@ final class ArrayLoaderTest extends TestCase
     }
 
     /**
-     * @param mixed $data
-     *
      * @dataProvider provideSupportingData
      */
-    public function testSupports($data, bool $expected): void
+    public function testSupports(mixed $data, bool $expected): void
     {
         $loader = new ArrayLoader(new MenuFactory());
 

--- a/tests/Knp/Menu/Tests/MenuTestCase.php
+++ b/tests/Knp/Menu/Tests/MenuTestCase.php
@@ -9,45 +9,21 @@ use PHPUnit\Framework\TestCase;
 
 abstract class MenuTestCase extends TestCase
 {
-    /**
-     * @var ItemInterface|null
-     */
-    protected $menu;
+    protected ItemInterface|null $menu;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $pt1;
+    protected ItemInterface|null $pt1;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $ch1;
+    protected ItemInterface|null $ch1;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $ch2;
+    protected ItemInterface|null $ch2;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $ch3;
+    protected ItemInterface|null $ch3;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $pt2;
+    protected ItemInterface|null $pt2;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $ch4;
+    protected ItemInterface|null $ch4;
 
-    /**
-     * @var ItemInterface|null
-     */
-    protected $gc1;
+    protected ItemInterface|null $gc1;
 
     protected function setUp(): void
     {

--- a/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
+++ b/tests/Knp/Menu/Tests/Renderer/AbstractRendererTest.php
@@ -12,10 +12,7 @@ use Knp\Menu\Tests\MenuTestCase;
 
 abstract class AbstractRendererTest extends MenuTestCase
 {
-    /**
-     * @var RendererInterface|null
-     */
-    protected $renderer;
+    protected RendererInterface|null $renderer;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
https://github.com/KnpLabs/KnpMenu/issues/374

Probably more could be changed. But i tried to not introduce any BC changes.

I am not sure how to handle the --prefer-lowest failing run (indirect deprecation notices from twig 1). https://github.com/Chris53897/KnpMenu/actions/runs/4971653642/jobs/8896326293

https://symfony.com/doc/current/components/phpunit_bridge.html#direct-and-indirect-deprecations

