### PR TITLE
feat: drop support for PHP < 8.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,20 +29,18 @@ jobs:
             matrix:
                 include:
                     - description: 'No Symfony specified'
-                      php: '8.0'
-                    - description: 'No Symfony specified'
                       php: '8.1'
                     - description: 'No Symfony specified'
                       php: '8.2'
                     - description: 'No Symfony specified'
                       php: '8.3'
                     - description: 'Lowest deps'
-                      php: '8.0'
+                      php: '8.1'
                       composer_option: '--prefer-lowest'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: max[self]=0
                     - description: 'Symfony 5.4'
-                      php: '8.0'
+                      php: '8.1'
                       symfony: 5.4.*
                     - description: 'Dev deps'
                       php: '8.2'
@@ -77,6 +75,6 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.1'
             - run: composer update --no-interaction --no-progress --ansi
             - run: vendor/bin/phpstan analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.5 (unreleased)
 
 * Added CallbackVoter
+* Removed support for unsupported PHP version 8.0
 
 ## 3.4 (2023-05-17)
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/routing": "^5.4 || ^6.0 || ^7.0",
-        "twig/twig": "^2.9 || ^3.0"
+        "twig/twig": "^2.16 || ^3.0"
     },
     "suggest": {
         "twig/twig": "for the TwigRenderer and the integration with your templates"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "conflict": {
         "twig/twig": "<1.42.3 || >=2,<2.9"
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.6",
         "psr/container": "^1.0 || ^2.0",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^6.3",
+        "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/routing": "^5.4 || ^6.0 || ^7.0",
         "twig/twig": "^2.9 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^9.6",
         "psr/container": "^1.0 || ^2.0",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^6.4 || ^7.0",
+        "symfony/phpunit-bridge": "^7.0",
         "symfony/routing": "^5.4 || ^6.0 || ^7.0",
         "twig/twig": "^2.16 || ^3.0"
     },


### PR DESCRIPTION
allow "symfony/phpunit-bridge" 7

corresponding PR for KNPMenuBundle
https://github.com/KnpLabs/KnpMenuBundle/pull/471#issuecomment-1973867408

I need to bump twig version to get rid of deprecations to make the CI green for `--prefer-lowest`