### PR TITLE
:package: Use WeakMap instead of SplObjectStorage to avoid memory leak

### DIFF
--- a/src/Knp/Menu/Matcher/Matcher.php
+++ b/src/Knp/Menu/Matcher/Matcher.php
@@ -11,9 +11,9 @@ use Knp\Menu\Matcher\Voter\VoterInterface;
 class Matcher implements MatcherInterface
 {
     /**
-     * @var \SplObjectStorage<ItemInterface, bool>
+     * @var \WeakMap<ItemInterface, bool>
      */
-    private \SplObjectStorage $cache;
+    private \WeakMap $cache;
 
     /**
      * @var iterable|VoterInterface[]
@@ -26,7 +26,7 @@ class Matcher implements MatcherInterface
     public function __construct($voters = [])
     {
         $this->voters = $voters;
-        $this->cache = new \SplObjectStorage();
+        $this->cache = new \WeakMap();
     }
 
     public function isCurrent(ItemInterface $item): bool
@@ -71,6 +71,6 @@ class Matcher implements MatcherInterface
 
     public function clear(): void
     {
-        $this->cache = new \SplObjectStorage();
+        $this->cache = new \WeakMap();
     }
 }


### PR DESCRIPTION
https://www.php.net/manual/en/class.weakmap.php

Using WeakMap will avoid preserving objects in memory if they are presented only in cache