### PR TITLE
Fix twig runtime extension last modification time detection

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,12 @@ parameters:
 			path: src/Knp/Menu/Twig/MenuExtension.php
 
 		-
-			message: "#^Method Knp\\\\Menu\\\\Twig\\\\MenuRuntimeExtension\\:\\:getBreadcrumbsArray\\(\\) has parameter \\$subItem with no value type specified in iterable type array\\.$#"
+			message: "#^Method Knp\\\\Menu\\\\Twig\\\\MenuRuntime\\:\\:getBreadcrumbsArray\\(\\) has parameter \\$subItem with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Knp/Menu/Twig/MenuRuntimeExtension.php
+			path: src/Knp/Menu/Twig/MenuRuntime.php
 
 		-
 			message: "#^PHPDoc tag @param for parameter \\$subItem with type array\\<int\\|string, array\\<string, Knp\\\\Menu\\\\ItemInterface\\|string\\|null\\>\\|float\\|int\\|Knp\\\\Menu\\\\ItemInterface\\|string\\|null\\>\\|string\\|Traversable\\<mixed, array\\<string, Knp\\\\Menu\\\\ItemInterface\\|string\\|null\\>\\|float\\|int\\|Knp\\\\Menu\\\\ItemInterface\\|string\\|null\\> is not subtype of native type array\\|string\\|null\\.$#"
 			count: 1
-			path: src/Knp/Menu/Twig/MenuRuntimeExtension.php
+			path: src/Knp/Menu/Twig/MenuRuntime.php
 

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -12,7 +12,7 @@ use Twig\TwigTest;
 
 class MenuExtension extends AbstractExtension
 {
-    private ?MenuRuntimeExtension $runtimeExtension = null;
+    private ?MenuRuntime $runtimeExtension = null;
 
     public function __construct(
         ?Helper $helper = null,
@@ -21,7 +21,7 @@ class MenuExtension extends AbstractExtension
     ) {
         if (null !== $helper) {
             @trigger_error('Injecting dependencies is deprecated since v3.6 and will be removed in v4.', E_USER_DEPRECATED);
-            $this->runtimeExtension = new MenuRuntimeExtension($helper, $matcher, $menuManipulator);
+            $this->runtimeExtension = new MenuRuntime($helper, $matcher, $menuManipulator);
         }
     }
 
@@ -30,10 +30,10 @@ class MenuExtension extends AbstractExtension
         $legacy = null !== $this->runtimeExtension;
 
         return [
-             new TwigFunction('knp_menu_get', $legacy ? [$this, 'get'] : [MenuRuntimeExtension::class, 'get']),
-             new TwigFunction('knp_menu_render', $legacy ? [$this, 'render'] : [MenuRuntimeExtension::class, 'render'], ['is_safe' => ['html']]),
-             new TwigFunction('knp_menu_get_breadcrumbs_array', $legacy ? [$this, 'getBreadcrumbsArray'] : [MenuRuntimeExtension::class, 'getBreadcrumbsArray']),
-             new TwigFunction('knp_menu_get_current_item', $legacy ? [$this, 'getCurrentItem'] : [MenuRuntimeExtension::class, 'getCurrentItem']),
+             new TwigFunction('knp_menu_get', $legacy ? [$this, 'get'] : [MenuRuntime::class, 'get']),
+             new TwigFunction('knp_menu_render', $legacy ? [$this, 'render'] : [MenuRuntime::class, 'render'], ['is_safe' => ['html']]),
+             new TwigFunction('knp_menu_get_breadcrumbs_array', $legacy ? [$this, 'getBreadcrumbsArray'] : [MenuRuntime::class, 'getBreadcrumbsArray']),
+             new TwigFunction('knp_menu_get_current_item', $legacy ? [$this, 'getCurrentItem'] : [MenuRuntime::class, 'getCurrentItem']),
         ];
     }
 
@@ -42,7 +42,7 @@ class MenuExtension extends AbstractExtension
         $legacy = null !== $this->runtimeExtension;
 
         return [
-            new TwigFilter('knp_menu_as_string', $legacy ? [$this, 'pathAsString'] : [MenuRuntimeExtension::class, 'pathAsString']),
+            new TwigFilter('knp_menu_as_string', $legacy ? [$this, 'pathAsString'] : [MenuRuntime::class, 'pathAsString']),
             new TwigFilter('knp_menu_spaceless', [self::class, 'spaceless'], ['is_safe' => ['html']]),
         ];
     }
@@ -52,8 +52,8 @@ class MenuExtension extends AbstractExtension
         $legacy = null !== $this->runtimeExtension;
 
         return [
-            new TwigTest('knp_menu_current', $legacy ? [$this, 'isCurrent'] : [MenuRuntimeExtension::class, 'isCurrent']),
-            new TwigTest('knp_menu_ancestor', $legacy ? [$this, 'isAncestor'] : [MenuRuntimeExtension::class, 'isAncestor']),
+            new TwigTest('knp_menu_current', $legacy ? [$this, 'isCurrent'] : [MenuRuntime::class, 'isCurrent']),
+            new TwigTest('knp_menu_ancestor', $legacy ? [$this, 'isAncestor'] : [MenuRuntime::class, 'isAncestor']),
         ];
     }
 

--- a/src/Knp/Menu/Twig/MenuRuntime.php
+++ b/src/Knp/Menu/Twig/MenuRuntime.php
@@ -7,7 +7,7 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Util\MenuManipulator;
 use Twig\Extension\RuntimeExtensionInterface;
 
-class MenuRuntimeExtension implements RuntimeExtensionInterface
+class MenuRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
         private readonly Helper $helper,

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -6,7 +6,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Twig\Helper;
 use Knp\Menu\Twig\MenuExtension;
-use Knp\Menu\Twig\MenuRuntimeExtension;
+use Knp\Menu\Twig\MenuRuntime;
 use Knp\Menu\Util\MenuManipulator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -202,7 +202,7 @@ final class MenuExtensionTest extends TestCase
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
         $twig->addExtension(new MenuExtension());
         $twig->addRuntimeLoader(new FactoryRuntimeLoader([
-            MenuRuntimeExtension::class => fn () => new MenuRuntimeExtension(
+            MenuRuntime::class => fn () => new MenuRuntime(
                 $helper,
                 $matcher,
                 $menuManipulator,


### PR DESCRIPTION
This PR renames Twig runtime extension from `MenuRuntimeExtension.php` to `MenuRuntime.php` to follow [naming convention](https://github.com/twigphp/Twig/blob/7dca48a57ce105c4a5fb4a15d647f6da38ae3191/src/Extension/AbstractExtension.php#L60).
This allows Twig to know when to recompile template(s) if extension code has changed.
This _should_ not break BC because it is internal class not used anywhere else directly (correct me if I'm wrong).
As an alternative, we can provide our own `getLastModified` method implementation.