### PR TITLE
Restrict the API surface with internal and final tags

### DIFF
--- a/src/Knp/Menu/Factory/CoreExtension.php
+++ b/src/Knp/Menu/Factory/CoreExtension.php
@@ -6,6 +6,9 @@ use Knp\Menu\ItemInterface;
 
 /**
  * core factory extension with the main logic
+ *
+ * @final since 3.8.0
+ * @internal since 3.8.0
  */
 class CoreExtension implements ExtensionInterface
 {

--- a/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
+++ b/src/Knp/Menu/Integration/Symfony/RoutingExtension.php
@@ -8,6 +8,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Factory able to use the Symfony Routing component to build the url
+ *
+ * @final since 3.8.0
  */
 class RoutingExtension implements ExtensionInterface
 {

--- a/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
+++ b/src/Knp/Menu/Iterator/CurrentItemFilterIterator.php
@@ -10,6 +10,8 @@ use Knp\Menu\Matcher\MatcherInterface;
  *
  * @template TKey
  * @template-extends \FilterIterator<TKey, ItemInterface, \Iterator<TKey, ItemInterface>>
+ *
+ * @final since 3.8.0
  */
 class CurrentItemFilterIterator extends \FilterIterator
 {

--- a/src/Knp/Menu/Iterator/DisplayedItemFilterIterator.php
+++ b/src/Knp/Menu/Iterator/DisplayedItemFilterIterator.php
@@ -4,6 +4,8 @@ namespace Knp\Menu\Iterator;
 
 /**
  * Filter iterator keeping only current items
+ *
+ * @final since 3.8.0
  */
 class DisplayedItemFilterIterator extends \RecursiveFilterIterator
 {

--- a/src/Knp/Menu/Iterator/RecursiveItemIterator.php
+++ b/src/Knp/Menu/Iterator/RecursiveItemIterator.php
@@ -12,6 +12,8 @@ use Knp\Menu\ItemInterface;
  * @extends \IteratorIterator<TKey, ItemInterface, \Traversable<TKey, ItemInterface>>
  *
  * @implements \RecursiveIterator<TKey, ItemInterface>
+ *
+ * @final since 3.8.0
  */
 class RecursiveItemIterator extends \IteratorIterator implements \RecursiveIterator
 {

--- a/src/Knp/Menu/Loader/ArrayLoader.php
+++ b/src/Knp/Menu/Loader/ArrayLoader.php
@@ -9,6 +9,8 @@ use Knp\Menu\ItemInterface;
  * Loader importing a menu tree from an array.
  *
  * The array should match the output of MenuManipulator::toArray
+ *
+ * @final since 3.8.0
  */
 class ArrayLoader implements LoaderInterface
 {

--- a/src/Knp/Menu/Loader/NodeLoader.php
+++ b/src/Knp/Menu/Loader/NodeLoader.php
@@ -6,6 +6,9 @@ use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\NodeInterface;
 
+/**
+ * @final since 3.8.0
+ */
 class NodeLoader implements LoaderInterface
 {
     public function __construct(private FactoryInterface $factory)

--- a/src/Knp/Menu/Matcher/Matcher.php
+++ b/src/Knp/Menu/Matcher/Matcher.php
@@ -7,6 +7,8 @@ use Knp\Menu\Matcher\Voter\VoterInterface;
 
 /**
  * A MatcherInterface implementation using a voter system
+ *
+ * @final since 3.8.0
  */
 class Matcher implements MatcherInterface
 {

--- a/src/Knp/Menu/Matcher/Voter/RegexVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RegexVoter.php
@@ -7,6 +7,8 @@ use Knp\Menu\ItemInterface;
 /**
  * Implements the VoterInterface which can be used as voter for "current" class
  * `matchItem` will return true if the pattern you're searching for is found in the URI of the item
+ *
+ * @final since 3.8.0
  */
 class RegexVoter implements VoterInterface
 {

--- a/src/Knp/Menu/Matcher/Voter/RouteVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/RouteVoter.php
@@ -8,6 +8,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Voter based on the route
+ *
+ * @final since 3.8.0
  */
 class RouteVoter implements VoterInterface
 {

--- a/src/Knp/Menu/Matcher/Voter/UriVoter.php
+++ b/src/Knp/Menu/Matcher/Voter/UriVoter.php
@@ -6,6 +6,8 @@ use Knp\Menu\ItemInterface;
 
 /**
  * Voter based on the uri
+ *
+ * @final since 3.8.0
  */
 class UriVoter implements VoterInterface
 {

--- a/src/Knp/Menu/MenuFactory.php
+++ b/src/Knp/Menu/MenuFactory.php
@@ -7,6 +7,8 @@ use Knp\Menu\Factory\ExtensionInterface;
 
 /**
  * Factory to create a menu from a tree
+ *
+ * @final since 3.8.0
  */
 class MenuFactory implements FactoryInterface
 {

--- a/src/Knp/Menu/Provider/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Provider/ArrayAccessProvider.php
@@ -10,6 +10,8 @@ use Knp\Menu\ItemInterface;
  * In case the value stored in the registry is a callable rather than an ItemInterface,
  * it will be called with the options as first argument and the registry as second argument
  * and is expected to return a menu item.
+ *
+ * @final since 3.8.0
  */
 class ArrayAccessProvider implements MenuProviderInterface
 {

--- a/src/Knp/Menu/Provider/ChainProvider.php
+++ b/src/Knp/Menu/Provider/ChainProvider.php
@@ -4,6 +4,9 @@ namespace Knp\Menu\Provider;
 
 use Knp\Menu\ItemInterface;
 
+/**
+ * @final since 3.8.0
+ */
 class ChainProvider implements MenuProviderInterface
 {
     /**

--- a/src/Knp/Menu/Provider/LazyProvider.php
+++ b/src/Knp/Menu/Provider/LazyProvider.php
@@ -10,6 +10,8 @@ use Knp\Menu\ItemInterface;
  * Builders can either be callables or a factory for an object callable
  * represented as [Closure, method], where the Closure gets called
  * to instantiate the object.
+ *
+ * @final since 3.8.0
  */
 class LazyProvider implements MenuProviderInterface
 {

--- a/src/Knp/Menu/Provider/PsrProvider.php
+++ b/src/Knp/Menu/Provider/PsrProvider.php
@@ -10,6 +10,8 @@ use Psr\Container\ContainerInterface;
  *
  * This menu provider does not support using options, as it cannot pass them to the container
  * to alter the menu building. Use a different provider in case you need support for options.
+ *
+ * @final since 3.8.0
  */
 class PsrProvider implements MenuProviderInterface
 {

--- a/src/Knp/Menu/Renderer/ArrayAccessProvider.php
+++ b/src/Knp/Menu/Renderer/ArrayAccessProvider.php
@@ -4,6 +4,8 @@ namespace Knp\Menu\Renderer;
 
 /**
  * A renderer provider getting the renderers from a class implementing ArrayAccess.
+ *
+ * @final since 3.8.0
  */
 class ArrayAccessProvider implements RendererProviderInterface
 {

--- a/src/Knp/Menu/Renderer/ListRenderer.php
+++ b/src/Knp/Menu/Renderer/ListRenderer.php
@@ -7,6 +7,8 @@ use Knp\Menu\Matcher\MatcherInterface;
 
 /**
  * Renders MenuItem tree as unordered list
+ *
+ * @final since 3.8.0
  */
 class ListRenderer extends Renderer implements RendererInterface
 {

--- a/src/Knp/Menu/Renderer/PsrProvider.php
+++ b/src/Knp/Menu/Renderer/PsrProvider.php
@@ -9,6 +9,8 @@ use Psr\Container\ContainerInterface;
  *
  * This menu provider does not support using options, as it cannot pass them to the container
  * to alter the menu building. Use a different provider in case you need support for options.
+ *
+ * @final since 3.8.0
  */
 class PsrProvider implements RendererProviderInterface
 {

--- a/src/Knp/Menu/Renderer/TwigRenderer.php
+++ b/src/Knp/Menu/Renderer/TwigRenderer.php
@@ -6,6 +6,9 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Twig\Environment;
 
+/**
+ * @final since 3.8.0
+ */
 class TwigRenderer implements RendererInterface
 {
     /**

--- a/src/Knp/Menu/Twig/MenuExtension.php
+++ b/src/Knp/Menu/Twig/MenuExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 use Twig\TwigTest;
 
+/**
+ * @final since 3.8.0
+ */
 class MenuExtension extends AbstractExtension
 {
     private ?MenuRuntimeExtension $runtimeExtension = null;
@@ -68,6 +71,8 @@ class MenuExtension extends AbstractExtension
     /**
      * @param array<int, string>   $path
      * @param array<string, mixed> $options
+     *
+     * @internal since 3.8.0
      */
     public function get(ItemInterface|string $menu, array $path = [], array $options = []): ItemInterface
     {
@@ -79,6 +84,8 @@ class MenuExtension extends AbstractExtension
     /**
      * @param string|ItemInterface|array<ItemInterface|string> $menu
      * @param array<string, mixed>                             $options
+     *
+     * @internal since 3.8.0
      */
     public function render(array|ItemInterface|string $menu, array $options = [], ?string $renderer = null): string
     {
@@ -94,6 +101,8 @@ class MenuExtension extends AbstractExtension
      *
      * @return array<int, array<string, mixed>>
      * @phpstan-return list<array{label: string, uri: string|null, item: ItemInterface|null}>
+     *
+     * @internal since 3.8.0
      */
     public function getBreadcrumbsArray(array|ItemInterface|string $menu, array|string|null $subItem = null): array
     {
@@ -102,6 +111,9 @@ class MenuExtension extends AbstractExtension
         return $this->runtimeExtension->getBreadcrumbsArray($menu, $subItem);
     }
 
+    /**
+     * @internal since 3.8.0
+     */
     public function getCurrentItem(ItemInterface|string $menu): ItemInterface
     {
         assert(null !== $this->runtimeExtension);
@@ -109,6 +121,9 @@ class MenuExtension extends AbstractExtension
         return $this->runtimeExtension->getCurrentItem($menu);
     }
 
+    /**
+     * @internal since 3.8.0
+     */
     public function pathAsString(ItemInterface $menu, string $separator = ' > '): string
     {
         assert(null !== $this->runtimeExtension);
@@ -116,6 +131,9 @@ class MenuExtension extends AbstractExtension
         return $this->runtimeExtension->pathAsString($menu, $separator);
     }
 
+    /**
+     * @internal since 3.8.0
+     */
     public function isCurrent(ItemInterface $item): bool
     {
         assert(null !== $this->runtimeExtension);
@@ -123,6 +141,9 @@ class MenuExtension extends AbstractExtension
         return $this->runtimeExtension->isCurrent($item);
     }
 
+    /**
+     * @internal since 3.8.0
+     */
     public function isAncestor(ItemInterface $item, ?int $depth = null): bool
     {
         assert(null !== $this->runtimeExtension);

--- a/src/Knp/Menu/Twig/MenuRuntimeExtension.php
+++ b/src/Knp/Menu/Twig/MenuRuntimeExtension.php
@@ -7,6 +7,9 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Util\MenuManipulator;
 use Twig\Extension\RuntimeExtensionInterface;
 
+/**
+ * @final since 3.8.0
+ */
 class MenuRuntimeExtension implements RuntimeExtensionInterface
 {
     public function __construct(
@@ -21,6 +24,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
      *
      * @param array<int, string>   $path
      * @param array<string, mixed> $options
+     *
+     * @internal since 3.8.0
      */
     public function get(ItemInterface|string $menu, array $path = [], array $options = []): ItemInterface
     {
@@ -32,6 +37,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
      *
      * @param string|ItemInterface|array<ItemInterface|string> $menu
      * @param array<string, mixed>                             $options
+     *
+     * @internal since 3.8.0
      */
     public function render(array|ItemInterface|string $menu, array $options = [], ?string $renderer = null): string
     {
@@ -47,6 +54,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
      *
      * @return array<int, array<string, mixed>>
      * @phpstan-return list<array{label: string, uri: string|null, item: ItemInterface|null}>
+     *
+     * @internal since 3.8.0
      */
     public function getBreadcrumbsArray(array|ItemInterface|string $menu, array|string|null $subItem = null): array
     {
@@ -55,6 +64,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
 
     /**
      * Returns the current item of a menu.
+     *
+     * @internal since 3.8.0
      */
     public function getCurrentItem(ItemInterface|string $menu): ItemInterface
     {
@@ -73,6 +84,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
      * A string representation of this menu item
      *
      * e.g. Top Level > Second Level > This menu
+     *
+     * @internal since 3.8.0
      */
     public function pathAsString(ItemInterface $menu, string $separator = ' > '): string
     {
@@ -85,6 +98,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
 
     /**
      * Checks whether an item is current.
+     *
+     * @internal since 3.8.0
      */
     public function isCurrent(ItemInterface $item): bool
     {
@@ -99,6 +114,8 @@ class MenuRuntimeExtension implements RuntimeExtensionInterface
      * Checks whether an item is the ancestor of a current item.
      *
      * @param int|null $depth The max depth to look for the item
+     *
+     * @internal since 3.8.0
      */
     public function isAncestor(ItemInterface $item, ?int $depth = null): bool
     {


### PR DESCRIPTION
Those methods still need to consider BC impact for now until the next major version, but this will reduce the public API surface in the future.