### PR TITLE
feat: update worflow and composer to PHP 8.2 or upper

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
             matrix:
                 include:
                     - description: 'No Symfony specified'
-                      php: '8.1'
+                      php: '8.2'
                       max_deprecations: 0
                     - description: 'No Symfony specified'
                       php: '8.2'
@@ -56,11 +56,11 @@ jobs:
                       php: '8.5'
                       max_deprecations: 0
                     - description: 'Lowest deps'
-                      php: '8.1'
+                      php: '8.2'
                       composer_option: '--prefer-lowest'
                       max_deprecations: 0
                     - description: 'Symfony 6'
-                      php: '8.1'
+                      php: '8.2'
                       symfony: 6.4.*
                       max_deprecations: 0
                     - description: 'Dev deps'
@@ -99,6 +99,6 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.1'
+                  php-version: '8.2'
             - run: composer update --no-interaction --no-progress --ansi
             - run: vendor/bin/phpstan analyze

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "conflict": {
         "symfony/http-foundation": "<5.4",


### PR DESCRIPTION
Based in comment https://github.com/KnpLabs/KnpMenu/pull/351#issuecomment-3631557567

Updates the minimum required PHP version for the project from 8.1 to 8.2. 

The changes ensure that all build jobs, dependency management, and code analysis workflows are aligned with PHP 8.2, and the `composer.json` file now enforces this new requirement.

**PHP version upgrade:**

* Updated all relevant job configurations in `.github/workflows/build.yaml` to use PHP 8.2 instead of 8.1 for builds, dependency checks, and Symfony compatibility tests.
* Changed the PHP requirement in `composer.json` from `^8.1` to `^8.2`, enforcing the new minimum version for dependency management.