### PR TITLE
improve tests

### DIFF
--- a/tests/Knp/Menu/Tests/Iterator/IteratorTest.php
+++ b/tests/Knp/Menu/Tests/Iterator/IteratorTest.php
@@ -22,10 +22,10 @@ final class IteratorTest extends MenuTestCase
     {
         // Adding an item which does not provide a RecursiveIterator to be sure it works properly.
         $child = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $child->expects($this->any())
+        $child
             ->method('getName')
             ->willReturn('Foo');
-        $child->expects($this->any())
+        $child
             ->method('getIterator')
             ->willReturn(new \EmptyIterator());
         $this->menu->addChild($child);

--- a/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/MatcherTest.php
@@ -15,7 +15,7 @@ final class MatcherTest extends TestCase
     public function testItemFlag(?bool $flag, bool $expected): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('isCurrent')
             ->willReturn($flag);
 
@@ -55,7 +55,7 @@ final class MatcherTest extends TestCase
     public function testFlagWinsOverVoter(bool $value): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('isCurrent')
             ->willReturn($value);
 
@@ -74,7 +74,7 @@ final class MatcherTest extends TestCase
     public function testFirstVoterWins(bool $value): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('isCurrent')
             ->willReturn(null);
 
@@ -99,7 +99,7 @@ final class MatcherTest extends TestCase
     public function testVoterIterator(bool $value): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('isCurrent')
             ->willReturn(null);
 

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RegexVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RegexVoterTest.php
@@ -14,7 +14,7 @@ final class RegexVoterTest extends TestCase
     public function testMatching(?string $exp, ?string $itemUri, ?bool $expected): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('getUri')
             ->willReturn($itemUri);
 

--- a/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/RouteVoterTest.php
@@ -26,7 +26,7 @@ final class RouteVoterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('getExtra')
             ->with('routes')
             ->willReturn([['invalid' => 'array']]);
@@ -53,7 +53,7 @@ final class RouteVoterTest extends TestCase
     public function testMatching(?string $route, array $parameters, array $queryParameters, $itemRoutes, ?bool $expected): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('getExtra')
             ->with('routes')
             ->willReturn($itemRoutes)

--- a/tests/Knp/Menu/Tests/Matcher/Voter/UriVoterTest.php
+++ b/tests/Knp/Menu/Tests/Matcher/Voter/UriVoterTest.php
@@ -14,7 +14,7 @@ final class UriVoterTest extends TestCase
     public function testMatching(?string $uri, ?string $itemUri, ?bool $expected): void
     {
         $item = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $item->expects($this->any())
+        $item
             ->method('getUri')
             ->willReturn($itemUri);
 

--- a/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
+++ b/tests/Knp/Menu/Tests/Provider/ChainProviderTest.php
@@ -35,7 +35,7 @@ final class ChainProviderTest extends TestCase
     {
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
-        $innerProvider->expects($this->any())
+        $innerProvider
             ->method('has')
             ->with('default')
             ->willReturn(true)
@@ -54,7 +54,7 @@ final class ChainProviderTest extends TestCase
     {
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $innerProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
-        $innerProvider->expects($this->any())
+        $innerProvider
             ->method('has')
             ->with('default', ['foo' => 'bar'])
             ->willReturn(true)

--- a/tests/Knp/Menu/Tests/Twig/HelperTest.php
+++ b/tests/Knp/Menu/Tests/Twig/HelperTest.php
@@ -157,7 +157,7 @@ final class HelperTest extends TestCase
         $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $child = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $menu->expects($this->any())
+        $menu
             ->method('getChild')
             ->with('child')
             ->willReturn($child)
@@ -180,12 +180,12 @@ final class HelperTest extends TestCase
         $rendererProvider = $this->getMockBuilder(RendererProviderInterface::class)->getMock();
         $menuProvider = $this->getMockBuilder(MenuProviderInterface::class)->getMock();
         $child = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $child->expects($this->any())
+        $child
             ->method('getChild')
             ->willReturn(null)
         ;
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $menu->expects($this->any())
+        $menu
             ->method('getChild')
             ->with('child')
             ->willReturn($child)
@@ -205,7 +205,7 @@ final class HelperTest extends TestCase
     {
         $child = $this->getMockBuilder(ItemInterface::class)->getMock();
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
-        $menu->expects($this->any())
+        $menu
             ->method('getChild')
             ->with('child')
             ->willReturn($child)
@@ -244,7 +244,7 @@ final class HelperTest extends TestCase
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
 
         $manipulator = $this->getMockBuilder(MenuManipulator::class)->getMock();
-        $manipulator->expects($this->any())
+        $manipulator
             ->method('getBreadcrumbsArray')
             ->with($menu)
             ->willReturn(['A', 'B']);

--- a/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
+++ b/tests/Knp/Menu/Tests/Twig/MenuExtensionTest.php
@@ -89,7 +89,7 @@ final class MenuExtensionTest extends TestCase
     public function testGetBreadcrumbsArray(): void
     {
         $helper = $this->getHelperMock(['getBreadcrumbsArray']);
-        $helper->expects($this->any())
+        $helper
             ->method('getBreadcrumbsArray')
             ->with('default')
             ->willReturn(['A', 'B'])
@@ -103,11 +103,11 @@ final class MenuExtensionTest extends TestCase
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock(['get']);
         $manipulator = $this->getManipulatorMock(['getPathAsString']);
-        $helper->expects($this->any())
+        $helper
             ->method('get')
             ->with('default')
             ->willReturn($menu);
-        $manipulator->expects($this->any())
+        $manipulator
             ->method('getPathAsString')
             ->with($menu)
             ->willReturn('A > B')
@@ -121,7 +121,7 @@ final class MenuExtensionTest extends TestCase
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock([]);
         $matcher = $this->getMatcherMock();
-        $matcher->expects($this->any())
+        $matcher
             ->method('isCurrent')
             ->with($menu)
             ->willReturn(true)
@@ -135,7 +135,7 @@ final class MenuExtensionTest extends TestCase
         $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
         $helper = $this->getHelperMock([]);
         $matcher = $this->getMatcherMock();
-        $matcher->expects($this->any())
+        $matcher
             ->method('isAncestor')
             ->with($menu)
             ->willReturn(false)
@@ -154,7 +154,7 @@ final class MenuExtensionTest extends TestCase
             ->willReturn($menu)
         ;
         $matcher = $this->getMatcherMock();
-        $matcher->expects($this->any())
+        $matcher
             ->method('isCurrent')
             ->with($menu)
             ->willReturn(true)

--- a/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
+++ b/tests/Knp/Menu/Tests/Util/MenuManipulatorTest.php
@@ -196,7 +196,7 @@ final class MenuManipulatorTest extends MenuTestCase
 
         foreach (\range(1, 2) as $i) {
             $child = $this->getMockBuilder(ItemInterface::class)->getMock();
-            $child->expects($this->any())
+            $child
                 ->method('getName')
                 ->willReturn('Child '.$i)
             ;


### PR DESCRIPTION
Removing useless `any()` calls (which, by the way, are deprecated in the latest phpUnit version)